### PR TITLE
Add unit test to `DataStore`

### DIFF
--- a/NeuroID.xcodeproj/project.pbxproj
+++ b/NeuroID.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		6F39E8DB26CEAA0C00BE9834 /* SDKUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F39E8DA26CEAA0C00BE9834 /* SDKUITest.swift */; };
 		6F39E8E126CEAA7900BE9834 /* EventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F39E8E026CEAA7900BE9834 /* EventTests.swift */; };
 		6FF06B2A271FCAA700F6704C /* DataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF06B26271FCA8300F6704C /* DataStoreTests.swift */; };
+		8E189A7F28069280003B5926 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E189A7E28069280003B5926 /* Atomic.swift */; };
+		8E189A81280692B9003B5926 /* DataStoreEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E189A80280692B9003B5926 /* DataStoreEventTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +51,8 @@
 		6F39E8DC26CEAA0C00BE9834 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6F39E8E026CEAA7900BE9834 /* EventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTests.swift; sourceTree = "<group>"; };
 		6FF06B26271FCA8300F6704C /* DataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreTests.swift; sourceTree = "<group>"; };
+		8E189A7E28069280003B5926 /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
+		8E189A80280692B9003B5926 /* DataStoreEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreEventTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +107,7 @@
 		26BCF33E268DA3C40002C289 /* NeuroID */ = {
 			isa = PBXGroup;
 			children = (
+				8E189A7E28069280003B5926 /* Atomic.swift */,
 				26BCF349268DA7CF0002C289 /* DataStore.swift */,
 				26BCF34B268DA7CF0002C289 /* NIDEvent.swift */,
 				26BCF340268DA3C40002C289 /* Info.plist */,
@@ -129,6 +134,7 @@
 				6F39E8CB26CEA9A800BE9834 /* SessionTests.swift */,
 				6F39E8CD26CEA9A800BE9834 /* Info.plist */,
 				6F39E8E026CEAA7900BE9834 /* EventTests.swift */,
+				8E189A80280692B9003B5926 /* DataStoreEventTests.swift */,
 			);
 			path = SDKTest;
 			sourceTree = "<group>";
@@ -283,6 +289,7 @@
 				26BCF34D268DA7CF0002C289 /* NeuroIDTracker.swift in Sources */,
 				6F39E8AA26CE9F7B00BE9834 /* SDKPreferences.swift in Sources */,
 				26BCF34C268DA7CF0002C289 /* DataStore.swift in Sources */,
+				8E189A7F28069280003B5926 /* Atomic.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -290,6 +297,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8E189A81280692B9003B5926 /* DataStoreEventTests.swift in Sources */,
 				6F39E8E126CEAA7900BE9834 /* EventTests.swift in Sources */,
 				6F39E8CC26CEA9A800BE9834 /* SessionTests.swift in Sources */,
 				6FF06B2A271FCAA700F6704C /* DataStoreTests.swift in Sources */,

--- a/NeuroID.xcodeproj/xcshareddata/xcschemes/NeuroID.xcscheme
+++ b/NeuroID.xcodeproj/xcshareddata/xcschemes/NeuroID.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "26BCF33B268DA3C40002C289"
+            BuildableName = "NeuroID.framework"
+            BlueprintName = "NeuroID"
+            ReferencedContainer = "container:NeuroID.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/NeuroID/Atomic.swift
+++ b/NeuroID/Atomic.swift
@@ -1,0 +1,23 @@
+@propertyWrapper
+struct Atomic<Value> {
+    private var lock = os_unfair_lock_s()
+    private var value: Value
+
+    init(wrappedValue value: Value) {
+        self.value = value
+    }
+
+    var wrappedValue: Value {
+        mutating get {
+            os_unfair_lock_lock(&lock)
+            let value = self.value
+            os_unfair_lock_unlock(&lock)
+            return value
+        }
+        set {
+            os_unfair_lock_lock(&lock)
+            value = newValue
+            os_unfair_lock_unlock(&lock)
+        }
+    }
+}

--- a/NeuroID/DataStore.swift
+++ b/NeuroID/DataStore.swift
@@ -2,54 +2,37 @@ import Foundation
 
 public struct DataStore {
     static let eventsKey = "events_pending"
-    static var _events = [NIDEvent]()
-    private static let lock = NSLock()
-    
-    static var events: Array<NIDEvent> {
-        get { lock.withCriticalSection { _events } }
-        set { lock.withCriticalSection { _events = newValue } }
-    }
 
-    static func insertEvent(screen: String, event: NIDEvent)
-    {
-        if (NeuroID.isStopped()){
-            return;
+    @Atomic
+    static var events: [NIDEvent] = []
+
+    static func insertEvent(screen: String, event: NIDEvent) {
+        if NeuroID.isStopped() {
+            return
         }
-        
-        if (event.tg?["tgs"] != nil) {
-            if (NeuroID.excludedViewsTestIDs.contains(where: { $0 == event.tg!["tgs"]!.toString() })) {
-                return;
-            }
+
+        if event.tg?["tgs"] != nil, NeuroID.excludedViewsTestIDs.contains(where: { $0 == event.tg!["tgs"]!.toString() }) {
+            return
         }
+
         // Ensure this event is not on the exclude list
-        if (NeuroID.excludedViewsTestIDs.contains(where: {$0 == event.tgs || $0 == event.en})) {
-            return;
+        if NeuroID.excludedViewsTestIDs.contains(where: { $0 == event.tgs || $0 == event.en }) {
+            return
         }
-                
-        // Do not capture any events bound to RNScreensNavigationController as we will double count if we do
-        if let eventURL = event.url {
-            if (eventURL.contains("RNScreensNavigationController")) {
-                return
-            }
-        }
-        DispatchQueue.global(qos: .utility).sync {
-            DataStore.events.append(event)
-        }
-    }
-    
-    static func getAllEvents() ->  [NIDEvent]{
-        return self.events
-    }
-    
-    static func removeSentEvents() {
-        self.events = []
-    }
-}
 
-extension NSLocking {
-    func withCriticalSection<T>(block: () throws -> T) rethrows -> T {
-        lock()
-        defer { unlock() }
-        return try block()
+        // Do not capture any events bound to RNScreensNavigationController as we will double count if we do
+        if let eventURL = event.url, eventURL.contains("RNScreensNavigationController") {
+            return
+        }
+
+        events.append(event)
+    }
+
+    static func getAllEvents() -> [NIDEvent] {
+        events
+    }
+
+    static func removeSentEvents() {
+        events = []
     }
 }

--- a/NeuroID/NIDEvent.swift
+++ b/NeuroID/NIDEvent.swift
@@ -152,7 +152,7 @@ public struct EventCache: Codable {
     
 }
 
-public struct NIDEvent: Codable {
+public struct NIDEvent: Codable, Equatable {
     public let type: String
     var tg: [String: TargetValue]? = nil
     var tgs: String?

--- a/SDKTest/DataStoreEventTests.swift
+++ b/SDKTest/DataStoreEventTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import NeuroID
+
+final class DataStoreEventTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        DataStore.events = []
+        NeuroID.start()
+    }
+
+    override class func tearDown() {
+        DataStore.events = []
+        super.tearDown()
+    }
+
+    func test_eventIsNotInserted_whenNeuroIDIsStopped() {
+        // Given: Any event
+        let event = NIDEvent(customEvent: "fake-event", tg: nil, x: nil, y: nil)
+
+        //  When: NeuroID is stopped
+        NeuroID.stop()
+        XCTAssertTrue(NeuroID.isStopped())
+        //   And: There is an insert try
+        DataStore.insertEvent(screen: name, event: event)
+
+        //  Then: event is not inserted
+        XCTAssertTrue(DataStore.events.isEmpty)
+    }
+
+    func test_eventIsNotInserted_whenEventTargetIsInTheExcludedList() {
+        // Given: Any event
+        let fakeTestValue = "fake-value"
+        let event = NIDEvent(customEvent: "fake-event", tg: ["tgs": .string(fakeTestValue)], x: nil, y: nil)
+
+        XCTAssertFalse(NeuroID.isStopped())
+
+        //  When: Test value is in the excluded list
+        NeuroID.excludedViewsTestIDs = [fakeTestValue]
+        //   And: There is an insert try
+        DataStore.insertEvent(screen: name, event: event)
+
+        //  Then: event is not inserted
+        XCTAssertTrue(DataStore.events.isEmpty)
+    }
+
+    func test_eventIsNotInserted_whenENIsInTheExcludedList() {
+        // Given: Any event
+        let enValue = "fake-en-value"
+        let event = NIDEvent(eventName: .change, tgs: "", en: enValue, etn: "", et: "", ec: "", v: "", url: "")
+
+        XCTAssertFalse(NeuroID.isStopped())
+
+        //  When: EN value is in the excluded list
+        NeuroID.excludedViewsTestIDs = [enValue]
+        //   And: There is an insert try
+        DataStore.insertEvent(screen: name, event: event)
+
+        //  Then: event is not inserted
+        XCTAssertTrue(DataStore.events.isEmpty)
+    }
+
+    func test_eventIsNotInserted_whenEventURLContainsRNScreensNavigationController() {
+        // Given: Any event, with a url containing 'RNScreensNavigationController'
+        let urlValue = "app://RNScreensNavigationController"
+        let event = NIDEvent(eventName: .change, tgs: "", en: "", etn: "", et: "", ec: "", v: "", url: urlValue)
+
+        XCTAssertFalse(NeuroID.isStopped())
+
+        //  When: There is an insert try
+        DataStore.insertEvent(screen: name, event: event)
+
+        //  Then: event is not inserted
+        XCTAssertTrue(DataStore.events.isEmpty)
+    }
+
+    func test_multipleInserts_and_getAllEvents() {
+        let events = (1...20)
+            .map { index in
+                NIDEvent(customEvent: "fake-event-\(index)", tg: nil, x: nil, y: nil)
+            }
+
+        XCTAssertFalse(NeuroID.isStopped())
+
+        for (index, event) in events.enumerated() {
+            DataStore.insertEvent(screen: "screen-\(index)", event: event)
+        }
+
+        XCTAssertEqual(
+            events.sorted { $0.type > $1.type },
+            DataStore.getAllEvents().sorted { $0.type > $1.type }
+        )
+    }
+
+    func test_removeSentEvents_clearsTheEventsList() {
+        let eventsCount = 20
+
+        let events = (1...eventsCount)
+            .map { index in
+                NIDEvent(customEvent: "fake-event-\(index)", tg: nil, x: nil, y: nil)
+            }
+
+        for (index, event) in events.enumerated() {
+            DataStore.insertEvent(screen: "screen-\(index)", event: event)
+        }
+
+        XCTAssertEqual(eventsCount, DataStore.getAllEvents().count)
+
+        DataStore.removeSentEvents()
+
+        XCTAssertTrue(DataStore.getAllEvents().isEmpty)
+    }
+
+    func test_inserting_fromMultipleQueues() {
+        let eventsCount = 50
+        let events = (1...eventsCount)
+            .map { index in
+                NIDEvent(customEvent: "fake-event-\(index)", tg: nil, x: nil, y: nil)
+            }
+
+        let dispatchGroup = DispatchGroup()
+        let multithreadingInsert = expectation(description: "multithreading insert")
+
+        for (index, event) in events.enumerated() {
+            dispatchGroup.enter()
+            DispatchQueue.global().async {
+                DataStore.insertEvent(screen: "screen-\(index)", event: event)
+                dispatchGroup.leave()
+            }
+        }
+
+        dispatchGroup.notify(queue: .main) {
+            multithreadingInsert.fulfill()
+        }
+
+        wait(for: [multithreadingInsert], timeout: 1.0)
+    }
+}


### PR DESCRIPTION
resolves #10

Changes:

- Add an `Atomic` property wrapper to simulate what an `Actor` would do when bumping the iOS deployment target version.
    - Currently, the project has iOS 11 as deployment target. This is not allowing to use an `Actor` which is available on iOS 13+.
    - It uses the `os_unfair_lock_s` API, which has faster locks/unlocks than `NSLock` and `DispatchQueue.sync`.
- Update the `events` static var in `DataStore` to use the `Atomic` property wrapper.
- Add the unit tests for `DataStore`.
    - Includes a test case for verifying the `insert` action from multiple queues.
- Update the schema to display the code coverage when running the tests.
- Make `NIDEvent` equatable.