### PR TITLE
[ENG-3954] - update the workflow with new version

### DIFF
--- a/.github/workflows/github-actions-ios-staging.yml
+++ b/.github/workflows/github-actions-ios-staging.yml
@@ -49,10 +49,14 @@ jobs:
                 -H "Accept: application/vnd.github.v3+json" \
                 -H "Authorization: token ${{ secrets.API_TOKEN_GITHUB }}" \
                 https://api.github.com/repos/Neuro-ID/neuroid-ios-sdk-sandbox/dispatches \
-                -d '{"event_type":"on-demand-testflight-staging","client_payload":{"version":"4.ios-${{env.VERSION}}", "message": "${{ github.event.head_commit.message }}"}}'
-      
+                -d '{"event_type":"on-demand-testflight-staging","client_payload":{"version":"5.ios-${{env.VERSION}}", "message": "${{ github.event.head_commit.message }}"}}'
+
+  notifications:
+    runs-on: ubuntu-latest
+    needs: test
+    steps: 
       - name: Send Slack Notification on Success
-        if: ${{ success() }}
+        if: ${{ needs.test.result == 'success' }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: mobile-sdk-tech-team
@@ -64,7 +68,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
       - name: Send Slack Notification on Failure
-        if: ${{ failure() }}
+        if: ${{ needs.test.result != 'success' }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: mobile-sdk-tech-team

--- a/.github/workflows/github-actions-ios.yml
+++ b/.github/workflows/github-actions-ios.yml
@@ -85,9 +85,13 @@ jobs:
                 -H "Authorization: token ${{ secrets.API_TOKEN_GITHUB }}" \
                 https://api.github.com/repos/Neuro-ID/neuroid-reactnative-sdk/dispatches \
                 -d '{"event_type":"on-demand-testflight","client_payload":{"version":"5.ios-${{env.VERSION}}", "message": "${{ github.event.commits[0].message }}"}}'
-
+  
+  notifications:
+    runs-on: ubuntu-latest
+    needs: test
+    steps: 
       - name: Send Slack Notification on Success
-        if: ${{ success() }}
+        if: ${{ needs.test.result == 'success' }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: mobile-sdk-tech-team
@@ -99,7 +103,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
       - name: Send Slack Notification on Failure
-        if: ${{ failure() }}
+        if: ${{ needs.test.result != 'success' }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: mobile-sdk-tech-team
@@ -108,4 +112,4 @@ jobs:
           SLACK_MESSAGE: "Failed execution on main iOS sdk build"
           SLACK_TITLE: Failed main iOS SDK
           SLACK_USERNAME: rtBot
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}         
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}        

--- a/.github/workflows/github-actions-version-check.yml
+++ b/.github/workflows/github-actions-version-check.yml
@@ -78,28 +78,33 @@ jobs:
           git push
           set -e
 
-    - name: Send Slack Notification on Success
-      if: ${{ success() }}
-      uses: rtCamp/action-slack-notify@v2
-      env:
+  notifications:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [versionCheck]
+    steps: 
+      - name: Send Slack Notification on Success
+        if: ${{ needs.versionCheck.result == 'success' }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
           SLACK_CHANNEL: mobile-sdk-tech-team
           SLACK_COLOR: ${{ job.status }}
           SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: "Success execution on version build iOS sdk build"
-          SLACK_TITLE: Success version build iOS SDK
+          SLACK_MESSAGE: "Success execution on version check"
+          SLACK_TITLE: Success release iOS SDK
           SLACK_USERNAME: rtBot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-    - name: Send Slack Notification on Failure
-      if: ${{ failure() }}
-      uses: rtCamp/action-slack-notify@v2
-      env:
+      - name: Send Slack Notification on Failure
+        if: ${{ needs.versionCheck.result != 'success' }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
           SLACK_CHANNEL: mobile-sdk-tech-team
           SLACK_COLOR: ${{ job.status }}
           SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: "Failed execution on version build iOS sdk build"
-          SLACK_TITLE: Failed version build iOS SDK
+          SLACK_MESSAGE: "Failed execution on version check"
+          SLACK_TITLE: Failed release iOS SDK
           SLACK_USERNAME: rtBot
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}     
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}    
        
   


### PR DESCRIPTION
Divide the workflow on two jobs, so the notification system run on a linux (Ubuntu) machine