### PR TITLE
ENG-5919-edit prod sandbox deploy 

### DIFF
--- a/.github/workflows/ios-sandbox-deployment-prod.yml
+++ b/.github/workflows/ios-sandbox-deployment-prod.yml
@@ -45,7 +45,6 @@ jobs:
   deploySandboxApps:
     if: github.event.pull_request.merged && startsWith(github.head_ref, 'releases/')
     runs-on: macos-latest
-    needs: updateSchema
     steps:
       - name: Branch Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Prod sandbox deploy was getting skipped since the step it was depending on was running on mutually exclusive condition.