### PR TITLE
ENG-6239 - RN sdk marker

### DIFF
--- a/NeuroID.xcodeproj/project.pbxproj
+++ b/NeuroID.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		F21702D629D607E600133A1C /* NIDParamsCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F21702D529D607E600133A1C /* NIDParamsCreatorTests.swift */; };
 		F228AA8F2A0180F80004892F /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = F228AA8E2A0180F80004892F /* Resources */; };
 		F228AA902A0180F80004892F /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = F228AA8E2A0180F80004892F /* Resources */; };
+		F23B75542AC36F8A00A7DF4D /* NIDRN.swift in Sources */ = {isa = PBXBuildFile; fileRef = F23B75532AC36F8A00A7DF4D /* NIDRN.swift */; };
 		F251654A2A6EF74F00D41B89 /* UIScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25165482A6EF74700D41B89 /* UIScrollView.swift */; };
 		F25F4BA129DCBF4000E31B32 /* NeuroIDTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25F4BA029DCBF4000E31B32 /* NeuroIDTrackerTests.swift */; };
 		F25F4BA329DDB5C900E31B32 /* NeuroIDClassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25F4BA229DDB5C900E31B32 /* NeuroIDClassTests.swift */; };
@@ -149,6 +150,7 @@
 		F21702D329D6077600133A1C /* NIDParamsCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIDParamsCreator.swift; sourceTree = "<group>"; };
 		F21702D529D607E600133A1C /* NIDParamsCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIDParamsCreatorTests.swift; sourceTree = "<group>"; };
 		F228AA8E2A0180F80004892F /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = "<group>"; };
+		F23B75532AC36F8A00A7DF4D /* NIDRN.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIDRN.swift; sourceTree = "<group>"; };
 		F25165482A6EF74700D41B89 /* UIScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollView.swift; sourceTree = "<group>"; };
 		F25F4BA029DCBF4000E31B32 /* NeuroIDTrackerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NeuroIDTrackerTests.swift; sourceTree = "<group>"; };
 		F25F4BA229DDB5C900E31B32 /* NeuroIDClassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeuroIDClassTests.swift; sourceTree = "<group>"; };
@@ -369,6 +371,7 @@
 				F2AEE7402A27A719009690CB /* NIDEnv.swift */,
 				F2AEE7422A27A7B5009690CB /* NIDClientSiteId.swift */,
 				F2AEE7462A27A84B009690CB /* NIDSend.swift */,
+				F23B75532AC36F8A00A7DF4D /* NIDRN.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -637,6 +640,7 @@
 				F21702BC29D4CDF900133A1C /* Dictionary.swift in Sources */,
 				F2AEE73B2A27A684009690CB /* NIDForm.swift in Sources */,
 				07A05C2128B91B4D00509509 /* NIDMetadata.swift in Sources */,
+				F23B75542AC36F8A00A7DF4D /* NIDRN.swift in Sources */,
 				F21702D429D6077600133A1C /* NIDParamsCreator.swift in Sources */,
 				F2AEE73D2A27A6AE009690CB /* NIDScreen.swift in Sources */,
 				F2AEE73F2A27A6E9009690CB /* NIDUser.swift in Sources */,

--- a/NeuroID/NIDParamsCreator.swift
+++ b/NeuroID/NIDParamsCreator.swift
@@ -180,7 +180,7 @@ enum ParamsCreator {
     static func getSDKVersion() -> String {
         // Version MUST start with 4. in order to be processed correctly
         let version = Bundle(for: NeuroIDTracker.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-        return "5.ios-\(version ?? "?")"
+        return "5.ios-\(NeuroID.isRN ? "rn-" : "")\(version ?? "?")"
     }
 
     static func getCommandQueueNamespace() -> String {

--- a/NeuroID/NeuroIDClass/Extensions/NIDRN.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDRN.swift
@@ -1,0 +1,14 @@
+//
+//  NIDRN.swift
+//  NeuroID
+//
+//  Created by Kevin Sites on 9/26/23.
+//
+
+import Foundation
+
+public extension NeuroID {
+    static func isRNSDK() {
+        isRN = true
+    }
+}

--- a/NeuroID/NeuroIDClass/Extensions/NIDRN.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDRN.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public extension NeuroID {
-    static func isRNSDK() {
+    static func setIsRN() {
         isRN = true
     }
 }

--- a/NeuroID/NeuroIDClass/Extensions/NIDSend.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSend.swift
@@ -110,7 +110,7 @@ public extension NeuroID {
         let neuroHTTPRequest = NeuroHTTPRequest(
             clientId: NeuroID.getClientID(),
             environment: NeuroID.getEnvironment(),
-            sdkVersion: ParamsCreator.getSDKVersion(),
+            sdkVersion: NeuroID.getSDKVersion(),
             pageTag: NeuroID.getScreenName() ?? "UNKNOWN",
             responseId: ParamsCreator.generateUniqueHexId(),
             siteId: NeuroID.siteId ?? "",

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -26,7 +26,7 @@ public extension NeuroID {
             tch: ParamsCreator.getTouch(),
             pageTag: NeuroID.getScreenName(),
             ns: ParamsCreator.getCommandQueueNamespace(),
-            jsv: ParamsCreator.getSDKVersion(),
+            jsv: NeuroID.getSDKVersion(),
             sh: UIScreen.main.bounds.height,
             sw: UIScreen.main.bounds.width,
             metadata: NIDMetadata()
@@ -90,6 +90,7 @@ public extension NeuroID {
 
         event.attrs = [
             Attrs(n: "orientation", v: ParamsCreator.getOrientation()),
+            Attrs(n: "isRN", v: "\(isRN)"),
         ]
         saveEventToLocalDataStore(event)
     }

--- a/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/NeuroID/NeuroIDClass/NeuroID.swift
@@ -57,6 +57,8 @@ public enum NeuroID {
 
     public static var registeredTargets = [String]()
 
+    internal static var isRN: Bool = false
+
     // MARK: - Setup
 
     /// 1. Configure the SDK
@@ -140,7 +142,7 @@ public enum NeuroID {
 
     /// Get the current SDK versión from bundle
     /// - Returns: String with the version format
-    public static func getSDKVersion() -> String? {
+    public static func getSDKVersion() -> String {
         return ParamsCreator.getSDKVersion()
     }
 }

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -692,7 +692,7 @@ class NIDLogTests: XCTestCase {
 class NIDRNTests: XCTestCase {
     func test_isRN() {
         assert(!NeuroID.isRN)
-        NeuroID.isRNSDK()
+        NeuroID.setIsRN()
 
         assert(NeuroID.isRN)
     }

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -689,6 +689,15 @@ class NIDLogTests: XCTestCase {
     }
 }
 
+class NIDRNTests: XCTestCase {
+    func test_isRN() {
+        assert(!NeuroID.isRN)
+        NeuroID.isRNSDK()
+
+        assert(NeuroID.isRN)
+    }
+}
+
 // swizzle
 // initTimer
 // send


### PR DESCRIPTION
Added `isRN` bool var to the NeuroID Class
Added `setIsRN` method to mark isRN as true
Use `isRN` in the `getSDKVersion` method
Append a `isRN` key/value to the mobile metadata event