### PR TITLE
ENG-6130 - Add Advanced Device Functions

### DIFF
--- a/NeuroID.podspec
+++ b/NeuroID.podspec
@@ -17,8 +17,21 @@ s.source_files = "NeuroID/**/*.{h,c,m,swift,mlmodel,mlmodelc}"
 s.resource_bundles = {
     'Resources' => ['NeuroID/Resources/**/*', 'Info.plist']
 }
+s.exclude_files = 'NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift'
 
 s.dependency 'Alamofire'
+
+s.default_subspecs = 'Core'
+s.subspec 'Core' do |core|
+    core.source_files = "NeuroID/**/*.{h,c,m,swift,mlmodel,mlmodelc}"
+    core.exclude_files = 'NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift'
+end
+
+s.subspec 'AdvancedDevice' do |advanced|
+    advanced.ios.deployment_target = '12.0'
+    advanced.source_files = "NeuroID/**/*.{h,c,m,swift,mlmodel,mlmodelc}"
+    advanced.dependency 'NeuroIDAdvancedDevice'
+end
 
 s.license = { :type => "MIT", :text => <<-LICENSE
 Copyright (c) 2021 Neuro-ID <product@neuro-id.com>

--- a/NeuroID.xcodeproj/project.pbxproj
+++ b/NeuroID.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -60,6 +60,7 @@
 		F228AA8F2A0180F80004892F /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = F228AA8E2A0180F80004892F /* Resources */; };
 		F228AA902A0180F80004892F /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = F228AA8E2A0180F80004892F /* Resources */; };
 		F23B75542AC36F8A00A7DF4D /* NIDRN.swift in Sources */ = {isa = PBXBuildFile; fileRef = F23B75532AC36F8A00A7DF4D /* NIDRN.swift */; };
+		F2506FD12AD9A4FB00AD0903 /* NIDAdvancedDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2506FD02AD9A4FB00AD0903 /* NIDAdvancedDevice.swift */; };
 		F251654A2A6EF74F00D41B89 /* UIScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25165482A6EF74700D41B89 /* UIScrollView.swift */; };
 		F25F4BA129DCBF4000E31B32 /* NeuroIDTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25F4BA029DCBF4000E31B32 /* NeuroIDTrackerTests.swift */; };
 		F25F4BA329DDB5C900E31B32 /* NeuroIDClassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25F4BA229DDB5C900E31B32 /* NeuroIDClassTests.swift */; };
@@ -151,6 +152,7 @@
 		F21702D529D607E600133A1C /* NIDParamsCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIDParamsCreatorTests.swift; sourceTree = "<group>"; };
 		F228AA8E2A0180F80004892F /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = "<group>"; };
 		F23B75532AC36F8A00A7DF4D /* NIDRN.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIDRN.swift; sourceTree = "<group>"; };
+		F2506FD02AD9A4FB00AD0903 /* NIDAdvancedDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIDAdvancedDevice.swift; sourceTree = "<group>"; };
 		F25165482A6EF74700D41B89 /* UIScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollView.swift; sourceTree = "<group>"; };
 		F25F4BA029DCBF4000E31B32 /* NeuroIDTrackerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NeuroIDTrackerTests.swift; sourceTree = "<group>"; };
 		F25F4BA229DDB5C900E31B32 /* NeuroIDClassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeuroIDClassTests.swift; sourceTree = "<group>"; };
@@ -372,6 +374,7 @@
 				F2AEE7422A27A7B5009690CB /* NIDClientSiteId.swift */,
 				F2AEE7462A27A84B009690CB /* NIDSend.swift */,
 				F23B75532AC36F8A00A7DF4D /* NIDRN.swift */,
+				F2506FD02AD9A4FB00AD0903 /* NIDAdvancedDevice.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";

--- a/NeuroID/Constants.swift
+++ b/NeuroID/Constants.swift
@@ -30,6 +30,8 @@ internal enum Constants: String {
     case storageSessionExpiredKey = "nid_sid_expires"
     case storageSaltKey = "nid_sk"
 
+    case storageAdvancedDeviceKey = "nid_advancedDevice"
+
     case orientationKey = "orientation"
     case orientationLandscape = "Landscape"
     case orientationPortrait = "Portrait"

--- a/NeuroID/DataStore.swift
+++ b/NeuroID/DataStore.swift
@@ -78,6 +78,10 @@ internal func getUserDefaultKeyString(_ key: String) -> String? {
     return UserDefaults.standard.string(forKey: key)
 }
 
+internal func getUserDefaultKeyDict(_ key: String) -> String? {
+    return UserDefaults.standard.dictionary(forKey: key)
+}
+
 internal func setUserDefaultKey(_ key: String, value: Any?) {
     UserDefaults.standard.set(value, forKey: key)
 }

--- a/NeuroID/NIDEvent.swift
+++ b/NeuroID/NIDEvent.swift
@@ -80,6 +80,8 @@ public enum NIDEventName: String {
 
     case mobileMetadataIOS = "MOBILE_METADATA_IOS"
 
+    case advancedDevice = "ADVANCED_DEVICE_REQUEST"
+
     var etn: String? {
         switch self {
         case .change, .textChange, .radioChange, .inputChange,
@@ -255,6 +257,7 @@ public class NIDEvent: Codable {
     var sid: String? // Done
     var cid: String? // Done
     var did: String? // Done
+    var rid: String?
     var loc: String? // Done
     var ua: String? // Done
     var tzo: Int? // Done
@@ -277,6 +280,9 @@ public class NIDEvent: Codable {
     var sh: CGFloat?
     var sw: CGFloat?
     var rts: String?
+
+    var m: String? // part of LOG events
+    var level: String? // part of LOG events
 
     /** Register Target
        {"type":"REGISTER_TARGET","tgs":"#happyforms_message_nonce","en":"happyforms_message_nonce","eid":"happyforms_message_nonce","ec":"","etn":"INPUT","et":"hidden","ef":null,"v":"S~C~~10","ts":1633972363470}
@@ -476,6 +482,7 @@ public class NIDEvent: Codable {
         copy.sid = self.sid
         copy.cid = self.cid
         copy.did = self.did
+        copy.rid = self.rid
         copy.loc = self.loc
         copy.ua = self.ua
         copy.tzo = self.tzo

--- a/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
@@ -1,0 +1,55 @@
+//
+//  NIDAdvancedDevice.swift
+//  NeuroID
+//
+//  Created by Kevin Sites on 10/13/23.
+//
+
+import Foundation
+import NeuroIDAdvancedDevice
+
+public extension NeuroID {
+    static func start(advancedDeviceSignals: Bool) {
+        NeuroID.start()
+        
+        if advancedDeviceSignals {
+            // call stored value, if expired then clear and get new one, else send existing
+            if let storedADVKey = getUserDefaultKeyDict(Constants.storageAdvancedDeviceKey.rawValue) {
+                if let exp = storedADVKey["exp"] as? Int, let requestID = storedADVKey["key"] as? String {
+                    let currentTimeEpoch = Date().timeIntervalSince1970
+                    
+                    if currentTimeEpoch < exp {
+                        let nidEvent = NIDEvent(type: .advancedDevice)
+                        nidEvent.rid = requestID
+                        
+                        NeuroID.saveEventToLocalDataStore(nidEvent)
+                        return
+                    }
+                }
+            }
+            
+            NeuroIDADV.getAdvancedDeviceSignal(NeuroID.clientKey ?? "") { request in
+                switch request {
+                case .success(let requestID):
+                    let nidEvent = NIDEvent(type: .advancedDevice)
+                    nidEvent.rid = requestID
+                        
+                    NeuroID.saveEventToLocalDataStore(nidEvent)
+                        
+                    setUserDefaultKey(
+                        Constants.storageAdvancedDeviceKey.rawValue,
+                        value: ["exp": UtilFunctions.getFutureTimeStamp(24),
+                                "key": requestID]
+                    )
+                case .failure(let error):
+                    let nidEvent = NIDEvent(type: .log)
+                    nidEvent.m = error.localizedDescription
+                    nidEvent.level = "ERROR"
+                        
+                    NeuroID.saveEventToLocalDataStore(nidEvent)
+                    return
+                }
+            }
+        }
+    }
+}

--- a/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/NeuroID/TrackerClassExtensions/Utils.swift
@@ -9,6 +9,21 @@ import Foundation
 import UIKit
 
 internal enum UtilFunctions {
+    static func getFutureTimeStamp(_ hoursToAdd: Int) -> Int {
+        // Get the current time
+        let currentTime = Date()
+
+        // Create a Calendar object
+        var calendar = Calendar.current
+
+        // Add the specified number of hours to the current time
+        if let futureTime = calendar.date(byAdding: .hour, value: hoursToAdd, to: currentTime) {
+            return Int(futureTime.timeIntervalSince1970)
+        } else {
+            return 0
+        }
+    }
+
     static func getFullViewlURLPath(currView: UIView?, screenName: String) -> String {
         if currView == nil {
             return screenName


### PR DESCRIPTION
This PR will do a couple of things:
1. Breaks our Podspec file into multiple "subspecs" that can be installed individually with our "Core" SDK as the default install so that `pod 'NeuroID'` will still get our regular functionality
2. The second subspec is now `AdvancedDevice` meaning someone would want to put `pod 'NeuroID' ` && `pod 'NeuroID/AdvancedDevice'` to include our new work. As part of the work for Advanced Device the customer will be required to have a min deployment target of iOS 12 (we currently support back to iOS 11) or it will not install.
3. To call the new function all the customer has to do is call `NeuroID.start(true)` to begin advanced device tracking. If they just call `NeuroID.start()` or `NeuroID.start(false)` they will get our original behavior