### PR TITLE
ENG-6729, change visibility to public in StartSessionResult

### DIFF
--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -9,8 +9,8 @@ import Foundation
 import UIKit
 
 public struct SessionStartResult {
-    let started: Bool
-    let sessionID: String
+    public let started: Bool
+    public let sessionID: String
 
     init(_ started: Bool, _ sessionID: String) {
         self.started = started


### PR DESCRIPTION
Need to change visibility to public to allow RN to see the session started flag and session ID. 
![image](https://github.com/Neuro-ID/neuroid-ios-sdk/assets/139158682/a62e6c99-cf1b-4f74-9c5d-880af6db6eb3)
