### PR TITLE
ENG-7490-moved slack notifications to another container

### DIFF
--- a/.github/workflows/ios-sandbox-deployment-dev.yml
+++ b/.github/workflows/ios-sandbox-deployment-dev.yml
@@ -19,9 +19,13 @@ env:
   VERSION: "2.0.0"
 
 jobs:
-  test:
+  deploySandboxApps:
     runs-on: macos-latest
     if: github.event.pull_request.merged && startsWith(github.head_ref, 'releases/') != true
+    outputs:
+      slack-message: ${{ steps.slack-settings.outputs.SLACK_MESSAGE }}
+      slack-title: ${{ steps.slack-settings.outputs.SLACK_TITLE }}
+      slack-color: ${{ steps.slack-settings.outputs.SLACK_COLOR }}
     steps:
       - name: Branch Checkout
         uses: actions/checkout@v3
@@ -104,27 +108,33 @@ jobs:
               -H "Authorization: token ${{ secrets.GPR_API_KEY }}" \
               https://api.github.com/repos/Neuro-ID/neuroid-reactnative-sdk/dispatches \
               -d '{"event_type":"on-demand-testflight-dev","client_payload":{"version":"5.ios-${{env.VERSION}}", "message": "${{ github.event.commits[0].message }}"}}'
-
-      - name: Send Slack Notification on Success
-        if: success()
+      
+      - name: Set Slack message
+        id: slack-settings
+        if: always()
+        run: |
+            if [[ "${{ job.status }}" == "success" ]]; then
+              echo "SLACK_COLOR=${{ job.status }}" >> $GITHUB_OUTPUT
+              echo "SLACK_MESSAGE=Successful Dev Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
+              echo "SLACK_TITLE=Successful Dev Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
+            elif [[ "${{ job.status }}" == "failure" ]]; then
+              echo "SLACK_COLOR=${{ job.status }}" >> $GITHUB_OUTPUT
+              echo "SLACK_MESSAGE=Failed Dev Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
+              echo "SLACK_TITLE=Failed Dev Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
+            fi            
+  notifications:
+    runs-on: ubuntu-latest
+    needs: deploySandboxApps
+    if: always()
+    steps:
+      - name: Send Slack Notification Status
+        if: always()
         uses: rtCamp/action-slack-notify@v2
-        env:
+        env: 
           SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: "Successful Dev Sandbox Deployment for iOS"
-          SLACK_TITLE: Successful Dev Sandbox Deployment for iOS
-          SLACK_USERNAME: rtBot
           SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}
-
-      - name: Send Slack Notification on Failure
-        if: failure()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
-          SLACK_COLOR: ${{ job.status }}
+          SLACK_COLOR: ${{ needs.deploySandboxApps.outputs.slack-color}}
           SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: "Failed Dev Sandbox Deployment for iOS"
-          SLACK_TITLE: Failed Dev Sandbox Deployment for iOS
+          SLACK_MESSAGE: ${{needs.deploySandboxApps.outputs.slack-message}}
+          SLACK_TITLE:  ${{needs.deploySandboxApps.outputs.slack-title}}
           SLACK_USERNAME: rtBot
-          SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}

--- a/.github/workflows/ios-sandbox-deployment-dev.yml
+++ b/.github/workflows/ios-sandbox-deployment-dev.yml
@@ -128,7 +128,7 @@ jobs:
     if: always()
     steps:
       - name: Send Slack Notification Status
-        if: ${{needs.testflight-dev.outputs.slack-message}} != null
+        if: needs.testflight-dev.outputs.slack-message
         uses: rtCamp/action-slack-notify@v2
         env: 
           SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}

--- a/.github/workflows/ios-sandbox-deployment-dev.yml
+++ b/.github/workflows/ios-sandbox-deployment-dev.yml
@@ -19,7 +19,7 @@ env:
   VERSION: "2.0.0"
 
 jobs:
-  deploySandboxApps:
+  testflight-dev:
     runs-on: macos-latest
     if: github.event.pull_request.merged && startsWith(github.head_ref, 'releases/') != true
     outputs:
@@ -121,20 +121,22 @@ jobs:
               echo "SLACK_COLOR=${{ job.status }}" >> $GITHUB_OUTPUT
               echo "SLACK_MESSAGE=Failed Dev Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
               echo "SLACK_TITLE=Failed Dev Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
+            else
+              echo "SLACK_MESSAGE=Notification not needed" >> $GITHUB_OUTPUT
             fi            
   notifications:
     runs-on: ubuntu-latest
-    needs: deploySandboxApps
+    needs: testflight-dev
     if: always()
     steps:
       - name: Send Slack Notification Status
-        if: always()
+        if: ${{needs.testflight-dev.outputs.slack-message}} != 'Notification not needed'
         uses: rtCamp/action-slack-notify@v2
         env: 
           SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
           SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}
-          SLACK_COLOR: ${{ needs.deploySandboxApps.outputs.slack-color}}
+          SLACK_COLOR: ${{ needs.testflight-dev.outputs.slack-color}}
           SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: ${{needs.deploySandboxApps.outputs.slack-message}}
-          SLACK_TITLE:  ${{needs.deploySandboxApps.outputs.slack-title}}
+          SLACK_MESSAGE: ${{needs.testflight-dev.outputs.slack-message}}
+          SLACK_TITLE:  ${{needs.testflight-dev.outputs.slack-title}}
           SLACK_USERNAME: rtBot

--- a/.github/workflows/ios-sandbox-deployment-dev.yml
+++ b/.github/workflows/ios-sandbox-deployment-dev.yml
@@ -121,8 +121,6 @@ jobs:
               echo "SLACK_COLOR=${{ job.status }}" >> $GITHUB_OUTPUT
               echo "SLACK_MESSAGE=Failed Dev Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
               echo "SLACK_TITLE=Failed Dev Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
-            else
-              echo "SLACK_MESSAGE=Notification not needed" >> $GITHUB_OUTPUT
             fi            
   notifications:
     runs-on: ubuntu-latest
@@ -130,7 +128,7 @@ jobs:
     if: always()
     steps:
       - name: Send Slack Notification Status
-        if: ${{needs.testflight-dev.outputs.slack-message}} != 'Notification not needed'
+        if: ${{needs.testflight-dev.outputs.slack-message}} != null
         uses: rtCamp/action-slack-notify@v2
         env: 
           SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}

--- a/.github/workflows/ios-sandbox-deployment-prod.yml
+++ b/.github/workflows/ios-sandbox-deployment-prod.yml
@@ -133,8 +133,6 @@ jobs:
               echo "SLACK_COLOR=${{ job.status }}" >> $GITHUB_OUTPUT
               echo "SLACK_MESSAGE=Failed Prod Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
               echo "SLACK_TITLE=Failed Prod Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
-            else
-              echo "SLACK_MESSAGE=Notification not needed" >> $GITHUB_OUTPUT
             fi            
   notifications:
     runs-on: ubuntu-latest
@@ -142,7 +140,7 @@ jobs:
     if: always()
     steps:
       - name: Send Slack Notification Status
-        if: ${{needs.testflight.outputs.slack-message}} != 'Notification not needed'
+        if: needs.testflight.outputs.slack-message
         uses: rtCamp/action-slack-notify@v2
         env: 
           SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}

--- a/.github/workflows/ios-sandbox-deployment-prod.yml
+++ b/.github/workflows/ios-sandbox-deployment-prod.yml
@@ -44,6 +44,10 @@ jobs:
 
   deploySandboxApps:
     if: github.event.pull_request.merged && startsWith(github.head_ref, 'releases/')
+    outputs:
+      slack-message: ${{ steps.slack-settings.outputs.SLACK_MESSAGE }}
+      slack-title: ${{ steps.slack-settings.outputs.SLACK_TITLE }}
+      slack-color: ${{ steps.slack-settings.outputs.SLACK_COLOR }}
     runs-on: macos-latest
     steps:
       - name: Branch Checkout
@@ -117,27 +121,32 @@ jobs:
              -H "Authorization: token ${{ secrets.GPR_API_KEY }}" \
              https://api.github.com/repos/Neuro-ID/neuroid-reactnative-sdk/dispatches \
              -d '{"event_type":"on-demand-testflight","client_payload":{"version":"5.ios-${{env.VERSION}}", "message": "${{ github.event.commits[0].message }}"}}'
-
-      - name: Send Slack Notification on Success
-        if: success()
+      - name: Set Slack message
+        id: slack-settings
+        if: always()
+        run: |
+            if [[ "${{ job.status }}" == "success" ]]; then
+              echo "SLACK_COLOR=${{ job.status }}" >> $GITHUB_OUTPUT
+              echo "SLACK_MESSAGE=Successful Prod Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
+              echo "SLACK_TITLE=Successful Prod Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
+            elif [[ "${{ job.status }}" == "failure" ]]; then
+              echo "SLACK_COLOR=${{ job.status }}" >> $GITHUB_OUTPUT
+              echo "SLACK_MESSAGE=Failed Prod Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
+              echo "SLACK_TITLE=Failed Prod Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
+            fi            
+  notifications:
+    runs-on: ubuntu-latest
+    needs: deploySandboxApps
+    if: always()
+    steps:
+      - name: Send Slack Notification Status
+        if: always()
         uses: rtCamp/action-slack-notify@v2
-        env:
+        env: 
           SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: "Successful Prod Sandbox Deployment for iOS"
-          SLACK_TITLE: Successful Prod Sandbox Deployment for iOS
-          SLACK_USERNAME: rtBot
           SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}
-
-      - name: Send Slack Notification on Failure
-        if: failure()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
-          SLACK_COLOR: ${{ job.status }}
+          SLACK_COLOR: ${{ needs.deploySandboxApps.outputs.slack-color}}
           SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: "Failed Prod Sandbox Deployment for iOS"
-          SLACK_TITLE: Failed Prod Sandbox Deployment for iOS
+          SLACK_MESSAGE: ${{needs.deploySandboxApps.outputs.slack-message}}
+          SLACK_TITLE:  ${{needs.deploySandboxApps.outputs.slack-title}}
           SLACK_USERNAME: rtBot
-          SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}

--- a/.github/workflows/ios-sandbox-deployment-prod.yml
+++ b/.github/workflows/ios-sandbox-deployment-prod.yml
@@ -42,7 +42,7 @@ jobs:
           ls schema/
           cp schema/src/schema.json neuroid-ios-sdk/NeuroID/
 
-  deploySandboxApps:
+  testflight:
     if: github.event.pull_request.merged && startsWith(github.head_ref, 'releases/')
     outputs:
       slack-message: ${{ steps.slack-settings.outputs.SLACK_MESSAGE }}
@@ -133,20 +133,22 @@ jobs:
               echo "SLACK_COLOR=${{ job.status }}" >> $GITHUB_OUTPUT
               echo "SLACK_MESSAGE=Failed Prod Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
               echo "SLACK_TITLE=Failed Prod Sandbox Deployment for iOS" >> $GITHUB_OUTPUT
+            else
+              echo "SLACK_MESSAGE=Notification not needed" >> $GITHUB_OUTPUT
             fi            
   notifications:
     runs-on: ubuntu-latest
-    needs: deploySandboxApps
+    needs: testflight
     if: always()
     steps:
       - name: Send Slack Notification Status
-        if: always()
+        if: ${{needs.testflight.outputs.slack-message}} != 'Notification not needed'
         uses: rtCamp/action-slack-notify@v2
         env: 
           SLACK_CHANNEL: ${{ secrets.MOBILE_SLACK_NOTIFICATIONS_CHANNEL }}
           SLACK_WEBHOOK: ${{ secrets.MOBILE_SLACK_WEBHOOK }}
-          SLACK_COLOR: ${{ needs.deploySandboxApps.outputs.slack-color}}
+          SLACK_COLOR: ${{ needs.testflight.outputs.slack-color}}
           SLACK_ICON: https://github.com/rtCamp.png?size=48
-          SLACK_MESSAGE: ${{needs.deploySandboxApps.outputs.slack-message}}
-          SLACK_TITLE:  ${{needs.deploySandboxApps.outputs.slack-title}}
+          SLACK_MESSAGE: ${{needs.testflight.outputs.slack-message}}
+          SLACK_TITLE:  ${{needs.testflight.outputs.slack-title}}
           SLACK_USERNAME: rtBot


### PR DESCRIPTION
Github slack notification action only runs on linux containers. Moved step to its own job.