### PR TITLE
ENG-7771-updating development tag even on release

### DIFF
--- a/.github/workflows/ios-sandbox-deployment-dev.yml
+++ b/.github/workflows/ios-sandbox-deployment-dev.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   testflight-dev:
     runs-on: macos-latest
-    if: github.event.pull_request.merged && startsWith(github.head_ref, 'releases/') != true
+    if: github.event.pull_request.merged
     outputs:
       slack-message: ${{ steps.slack-settings.outputs.SLACK_MESSAGE }}
       slack-title: ${{ steps.slack-settings.outputs.SLACK_TITLE }}


### PR DESCRIPTION
Updating the ios sdk development tag even on a release so that the version number is pointing to the latest version in the podspec file.