### PR TITLE
ENG-7938 - Post Events Race Condition Fix

### DIFF
--- a/NeuroID/NeuroIDClass/Extensions/NIDSend.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSend.swift
@@ -135,15 +135,17 @@ extension NeuroID {
             return newEvent
         }
 
-        post(events: cleanEvents, screen: getScreenName() ?? altScreenName, onSuccess: { _ in
-            logInfo(category: "APICall", content: "Sending successfully")
-
-            completion()
-            // send success -> delete
-        }, onFailure: { error in
-            logError(category: "APICall", content: String(describing: error))
-            completion()
-        })
+        post(
+            events: cleanEvents,
+            screen: getScreenName() ?? altScreenName,
+            onSuccess: {
+                logInfo(category: "APICall", content: "Sending successfully")
+                completion()
+            }, onFailure: { error in
+                logError(category: "APICall", content: String(describing: error))
+                completion()
+            }
+        )
     }
 
     /// Direct send to API to create session
@@ -151,7 +153,7 @@ extension NeuroID {
     static func post(
         events: [NIDEvent],
         screen: String,
-        onSuccess: @escaping (Any) -> Void,
+        onSuccess: @escaping () -> Void,
         onFailure: @escaping
         (Error) -> Void
     ) {
@@ -202,9 +204,11 @@ extension NeuroID {
             switch response.result {
             case .success:
                 NIDLog.i("NeuroID post to API Successful")
+                onSuccess()
             case let .failure(error):
                 NIDLog.e("NeuroID FAIL to post API")
                 logError(content: "Neuro-ID post Error: \(error)")
+                onFailure(error)
             }
         }
 

--- a/NeuroID/NeuroIDClass/Extensions/NIDSend.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSend.swift
@@ -102,8 +102,12 @@ extension NeuroID {
     /**
      Publically exposed just for testing. This should not be any reason to call this directly.
      */
-    static func groupAndPOST(forceSend: Bool = false) {
+    static func groupAndPOST(
+        forceSend: Bool = false,
+        completion: @escaping () -> Void = {}
+    ) {
         if NeuroID.isStopped(), !forceSend {
+            completion()
             return
         }
 
@@ -111,6 +115,7 @@ extension NeuroID {
         let dataStoreEvents = DataStore.getAndRemoveAllEvents()
 
         if dataStoreEvents.isEmpty {
+            completion()
             return
         }
 
@@ -132,20 +137,24 @@ extension NeuroID {
 
         post(events: cleanEvents, screen: getScreenName() ?? altScreenName, onSuccess: { _ in
             logInfo(category: "APICall", content: "Sending successfully")
+
+            completion()
             // send success -> delete
         }, onFailure: { error in
             logError(category: "APICall", content: String(describing: error))
+            completion()
         })
     }
 
     /// Direct send to API to create session
     /// Regularly send in loop
-    static func post(events: [NIDEvent],
-                     screen: String,
-                     onSuccess: @escaping (Any) -> Void,
-                     onFailure: @escaping
-                     (Error) -> Void)
-    {
+    static func post(
+        events: [NIDEvent],
+        screen: String,
+        onSuccess: @escaping (Any) -> Void,
+        onFailure: @escaping
+        (Error) -> Void
+    ) {
         guard let url = URL(string: NeuroID.getCollectionEndpointURL()) else {
             logError(content: "NeuroID base URL found")
             return

--- a/NeuroID/TrackerEvents/AppEvents.swift
+++ b/NeuroID/TrackerEvents/AppEvents.swift
@@ -10,7 +10,7 @@ import UIKit
 
 // MARK: - App events
 
-internal extension NeuroIDTracker {
+extension NeuroIDTracker {
     func observeAppEvents() {
         if #available(iOS 13.0, *) {
             NotificationCenter.default.addObserver(self, selector: #selector(appMovedToBackground), name: UIScene.willDeactivateNotification, object: nil)
@@ -21,9 +21,8 @@ internal extension NeuroIDTracker {
 
             NotificationCenter.default.addObserver(self, selector: #selector(appMovedToForeground), name: UIApplication.didBecomeActiveNotification, object: nil)
         }
-        
+
         NotificationCenter.default.addObserver(self, selector: #selector(appLowMemoryWarning), name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
-                
     }
 
     @objc func appMovedToBackground() {
@@ -33,25 +32,29 @@ internal extension NeuroIDTracker {
     @objc func appMovedToForeground() {
         captureEvent(event: NIDEvent(type: NIDEventName.windowFocus))
     }
-    
+
     @objc func appLowMemoryWarning() {
         // Reduce memory footprint
         // Only clear this event queue the first time as it might be triggered a few times in a row (dropping our low mem event)
-        if (!NeuroID.lowMemory) {
+        if !NeuroID.lowMemory {
             DataStore.events = []
             DataStore.queuedEvents = []
             let lowMemEvent = NIDEvent(type: NIDEventName.lowMemory)
             lowMemEvent.url = NeuroID.getScreenName()
-           
-            NeuroID.post(events: [lowMemEvent], screen: NeuroID.getScreenName() ?? "low_mem_no_screen", onSuccess: { _ in
-                NeuroID.logInfo(category: "APICall", content: "Sending successfully")
-            }, onFailure: { error in
-                NeuroID.logError(category: "APICall", content: String(describing: error))
-            })
-            
+
+            NeuroID.post(
+                events: [lowMemEvent],
+                screen: NeuroID.getScreenName() ?? "low_mem_no_screen",
+                onSuccess: {
+                    NeuroID.logInfo(category: "APICall", content: "Sending successfully")
+                },
+                onFailure: { error in
+                    NeuroID.logError(category: "APICall", content: String(describing: error))
+                })
+
             NeuroID.lowMemory = true
         }
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
             NeuroID.lowMemory = false
         }

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -579,6 +579,37 @@ class NIDNewSessionTests: XCTestCase {
             NeuroID._isSDKStarted = false
         }
     }
+
+    func test_clearSendOldFlowEvents_not_sampled() {
+        DataStore.events.append(NIDEvent(rawType: "test"))
+        let mockSampling = NIDSamplingService()
+        mockSampling._isSessionFlowSampled = false
+        NeuroID.samplingService = mockSampling
+
+        NeuroID.clearSendOldFlowEvents {
+            assert(DataStore.events.count == 0)
+
+            NeuroID._isSDKStarted = false
+        }
+    }
+
+    func test_clearSendOldFlowEvents_sampled() {
+        DataStore.events.append(NIDEvent(rawType: "test"))
+        let mockSampling = NIDSamplingService()
+        mockSampling._isSessionFlowSampled = true
+        NeuroID.samplingService = mockSampling
+
+        let mockNetwork = NIDNetworkServiceTestImpl()
+        NeuroID.networkService = mockNetwork
+
+        NeuroID._isSDKStarted = true
+
+        NeuroID.clearSendOldFlowEvents {
+            assert(DataStore.events.count == 0)
+
+            NeuroID._isSDKStarted = false
+        }
+    }
 }
 
 class NIDFormTests: XCTestCase {


### PR DESCRIPTION
With automated testing @jeff-niemann  and I noticed that a packet could be sent with the wrong linkedSiteID because we send events which is async and then update the linkedSiteID. This is because of the race condition between sending the events and updating the static class variable. This PR introduces a callback for the posting of events to force the function to wait until the packet has been sent with the correct linkedSiteID.