### PR TITLE
ENG-8088 - Use viewIfLoaded

### DIFF
--- a/NeuroID/NeuroIDTracker.swift
+++ b/NeuroID/NeuroIDTracker.swift
@@ -223,7 +223,7 @@ extension NeuroIDTracker {
             return
         }
 
-        if let views = controller?.view.subviews {
+        if let views = controller?.viewIfLoaded?.subviews {
             observeViews(views)
         }
 

--- a/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/NeuroID/TrackerClassExtensions/Utils.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-internal enum UtilFunctions {
+enum UtilFunctions {
     static func getFutureTimeStamp(_ hoursToAdd: Int) -> Int {
         // Get the current time
         let currentTime = Date()
@@ -52,7 +52,7 @@ internal enum UtilFunctions {
             let guid = ParamsCreator.generateID()
 
             NeuroIDTracker.registerSingleView(v: view, screenName: screenName, guid: guid)
-            let childViews = ctrls.view.subviewsRecursive()
+            let childViews = view.subviewsRecursive()
             for _view in childViews {
                 NIDLog.d(tag: "\(Constants.registrationTag.rawValue)", "Registering single view.")
                 NeuroIDTracker.registerSingleView(v: _view, screenName: screenName, guid: guid)
@@ -213,12 +213,12 @@ internal enum UtilFunctions {
 
         // URL capture?
     }
-    
+
     static func captureCallStatusEvent(
         eventType: NIDEventName,
         status: String
     ) {
-        let event = NIDEvent( type: eventType )
+        let event = NIDEvent(type: eventType)
         event.cp = status
         NeuroID.saveEventToLocalDataStore(event)
     }

--- a/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/NeuroID/TrackerClassExtensions/Utils.swift
@@ -46,7 +46,7 @@ internal enum UtilFunctions {
         for ctrls in filtered {
             let screenName = ctrls.nidClassName
             NIDLog.d(tag: "\(Constants.registrationTag.rawValue)", "Registering view controllers \(screenName)")
-            guard let view = ctrls.view else {
+            guard let view = ctrls.viewIfLoaded else {
                 return
             }
             let guid = ParamsCreator.generateID()


### PR DESCRIPTION
To provide more context, the previous usage of ctrls.view would force the view to load even if it wasn't ready, the new ctrls.viewIfLoaded will only load the view if its already been completely loaded. This fixes an issue where a customer can edit/reload a view while we are in the middle of loading it.