### PR TITLE
ENG-8243-add call in progress event metadata

### DIFF
--- a/NeuroID/Constants.swift
+++ b/NeuroID/Constants.swift
@@ -79,3 +79,12 @@ enum CallInProgress: String {
     case INACTIVE = "false"
     case UNAUTHORIZED = "unauthorized"
 }
+
+enum CallInProgressMetaData: String {
+    case OUTGOING_RINGING = "outgoing ringing"
+    case OUTGOING_ANSWERED = "outgoing answered"
+    case OUTGOING_ENDED = "outgoing ended"
+    case INCOMING_RINGING = "incoming ringing"
+    case INCOMING_ANSWERED = "incoming answered"
+    case INCOMING_ENDED = "incoming ended"
+}

--- a/NeuroID/Constants.swift
+++ b/NeuroID/Constants.swift
@@ -81,13 +81,11 @@ enum CallInProgress: String {
 }
 
 enum CallInProgressMetaData: String {
-    case OUTGOING_RINGING = "outgoing ringing"
-    case OUTGOING_ANSWERED = "outgoing answered"
-    case OUTGOING_ENDED = "outgoing ended"
-    case INCOMING_RINGING = "incoming ringing"
-    case INCOMING_ANSWERED = "incoming answered"
-    case INCOMING_ENDED = "incoming ended"
-    case INCOMING_ONHOLD = "incoming on hold"
-    case OUTGOING_ONHOLD = "outgoing on hold"
-
+    case OUTGOING = "outgoing"
+    case INCOMING = "incoming"
+    case ANSWERED = "answered"
+    case ENDED = "ended"
+    case ONHOLD = "onhold"
+    case RINGING = "ringing"
+    
 }

--- a/NeuroID/Constants.swift
+++ b/NeuroID/Constants.swift
@@ -87,4 +87,7 @@ enum CallInProgressMetaData: String {
     case INCOMING_RINGING = "incoming ringing"
     case INCOMING_ANSWERED = "incoming answered"
     case INCOMING_ENDED = "incoming ended"
+    case INCOMING_ONHOLD = "incoming on hold"
+    case OUTGOING_ONHOLD = "outgoing on hold"
+
 }

--- a/NeuroID/NIDCallStatusObserver.swift
+++ b/NeuroID/NIDCallStatusObserver.swift
@@ -19,31 +19,45 @@ class NIDCallStatusObserver: NSObject, CXCallObserverDelegate {
     }
     
     func callObserver(_ callObserver: CXCallObserver, callChanged call: CXCall) {
-        //        Outgoing call answered
+        // Outgoing call answered
         if(call.isOutgoing && call.hasConnected && !call.hasEnded){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue, metadata: CallInProgressMetaData.OUTGOING_ANSWERED.rawValue)
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.OUTGOING_ANSWERED.rawValue) )
             NIDLog.d("Outgoing call (answered) observed /could be voice mail")}
-        //        Outgoing call ringing
+        
+        // Outgoing call ringing
         else if(call.isOutgoing && !call.hasConnected && !call.hasEnded){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, metadata: CallInProgressMetaData.OUTGOING_RINGING.rawValue)
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, attrs:Attrs(n: "callMeta", v: CallInProgressMetaData.OUTGOING_RINGING.rawValue) )
             NIDLog.d("Outgoing call (ringing) observed")}
-        //        Outgoing call ended
+        
+        // Outgoing call ended
         else if(call.isOutgoing && call.hasEnded){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, metadata: CallInProgressMetaData.OUTGOING_ENDED.rawValue)
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.OUTGOING_ENDED.rawValue) )
             NIDLog.d("Outgoing call ended")}
-        //        Incoming call ringing
+        
+        // Incoming call ringing
         else if(!call.isOutgoing && !call.hasConnected && !call.hasEnded){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, metadata: CallInProgressMetaData.INCOMING_RINGING.rawValue)
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.INCOMING_RINGING.rawValue) )
             NIDLog.d("Incoming call (ringing) in progress is observed")}
-        //        Incoming call answered
+        
+        // Incoming call answered
         else if(!call.isOutgoing && call.hasConnected && !call.hasEnded){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue, metadata: CallInProgressMetaData.INCOMING_ANSWERED.rawValue)
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.INCOMING_ANSWERED.rawValue) )
             NIDLog.d("Incoming call (answered)/voicemail in progress is observed")}
-        //        Incoming call ended
+        
+        // Incoming call ended
         else if(!call.isOutgoing && call.hasEnded){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, metadata: CallInProgressMetaData.INCOMING_ENDED.rawValue)
-            NIDLog.d("Incoming call ended ")}
- 
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.INCOMING_ENDED.rawValue) )
+            NIDLog.d("Incoming call ended")}
+        
+        // Incoming call on hold
+        else if(!call.isOutgoing && call.isOnHold){
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.INCOMING_ONHOLD.rawValue) )
+            NIDLog.d("Incoming call on hold")}
+        
+        // Outgoing call on hold
+        else if(call.isOutgoing && call.isOnHold){
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.OUTGOING_ONHOLD.rawValue) )
+            NIDLog.d("Outgoing call on hold")}
     }
     
     func startListeningToCallStatus() {

--- a/NeuroID/NIDCallStatusObserver.swift
+++ b/NeuroID/NIDCallStatusObserver.swift
@@ -19,22 +19,31 @@ class NIDCallStatusObserver: NSObject, CXCallObserverDelegate {
     }
     
     func callObserver(_ callObserver: CXCallObserver, callChanged call: CXCall) {
-        if call.hasEnded {
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue)
-            NIDLog.d("Call has ended")
-        } else if call.isOutgoing {
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue)
-            NIDLog.d("Ongoing call observed")
-        } else if call.hasConnected {
-            // Event not captured
-            NIDLog.d("Call connected")
-        } else if call.isOnHold {
-            // Event not captured
-            NIDLog.d("Call on hold")
-        } else {
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue)
-            NIDLog.d("Incoming Call observed")
-        }
+        //        Outgoing call answered
+        if(call.isOutgoing && call.hasConnected && !call.hasEnded){
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue, metadata: CallInProgressMetaData.OUTGOING_ANSWERED.rawValue)
+            NIDLog.d("Outgoing call (answered) observed /could be voice mail")}
+        //        Outgoing call ringing
+        else if(call.isOutgoing && !call.hasConnected && !call.hasEnded){
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, metadata: CallInProgressMetaData.OUTGOING_RINGING.rawValue)
+            NIDLog.d("Outgoing call (ringing) observed")}
+        //        Outgoing call ended
+        else if(call.isOutgoing && call.hasEnded){
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, metadata: CallInProgressMetaData.OUTGOING_ENDED.rawValue)
+            NIDLog.d("Outgoing call ended")}
+        //        Incoming call ringing
+        else if(!call.isOutgoing && !call.hasConnected && !call.hasEnded){
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, metadata: CallInProgressMetaData.INCOMING_RINGING.rawValue)
+            NIDLog.d("Incoming call (ringing) in progress is observed")}
+        //        Incoming call answered
+        else if(!call.isOutgoing && call.hasConnected && !call.hasEnded){
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue, metadata: CallInProgressMetaData.INCOMING_ANSWERED.rawValue)
+            NIDLog.d("Incoming call (answered)/voicemail in progress is observed")}
+        //        Incoming call ended
+        else if(!call.isOutgoing && call.hasEnded){
+            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, metadata: CallInProgressMetaData.INCOMING_ENDED.rawValue)
+            NIDLog.d("Incoming call ended ")}
+ 
     }
     
     func startListeningToCallStatus() {

--- a/NeuroID/NIDCallStatusObserver.swift
+++ b/NeuroID/NIDCallStatusObserver.swift
@@ -20,30 +20,32 @@ class NIDCallStatusObserver: NSObject, CXCallObserverDelegate {
     
     func callObserver(_ callObserver: CXCallObserver, callChanged call: CXCall) {
         var status: String
-        var attrs: Attrs
+        var attrs: [Attrs] = []
+        var progress: String
+        
+        // Add call type
+        attrs.append(Attrs(n:"type",v:call.isOutgoing ? CallInProgressMetaData.OUTGOING.rawValue : CallInProgressMetaData.INCOMING.rawValue))
         
         if call.hasEnded {
             status = CallInProgress.INACTIVE.rawValue
-            attrs = Attrs(n: call.isOutgoing ? CallInProgressMetaData.OUTGOING.rawValue : CallInProgressMetaData.INCOMING.rawValue,
-                          v: CallInProgressMetaData.ENDED.rawValue)
+            progress = CallInProgressMetaData.ENDED.rawValue
             
         } else if call.isOnHold {
             status = CallInProgress.ACTIVE.rawValue
-            attrs = Attrs(n: call.isOutgoing ? CallInProgressMetaData.OUTGOING.rawValue : CallInProgressMetaData.INCOMING.rawValue,
-                          v: CallInProgressMetaData.ONHOLD.rawValue)
+            progress = CallInProgressMetaData.ONHOLD.rawValue
             
         } else if call.hasConnected {
             status = CallInProgress.ACTIVE.rawValue
-            attrs = Attrs(n: call.isOutgoing ? CallInProgressMetaData.OUTGOING.rawValue : CallInProgressMetaData.INCOMING.rawValue,
-                          v: CallInProgressMetaData.ANSWERED.rawValue)
+            progress =  CallInProgressMetaData.ANSWERED.rawValue
             
         } else {
             status = CallInProgress.INACTIVE.rawValue
-            attrs = Attrs(n: call.isOutgoing ? CallInProgressMetaData.OUTGOING.rawValue : CallInProgressMetaData.INCOMING.rawValue,
-                          v: CallInProgressMetaData.RINGING.rawValue)
+            progress =  CallInProgressMetaData.RINGING.rawValue
             
         }
         
+        // Add call progress
+        attrs.append(Attrs(n: "progress", v: progress ))
         UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: status, attrs: attrs)
     }
     

--- a/NeuroID/NIDCallStatusObserver.swift
+++ b/NeuroID/NIDCallStatusObserver.swift
@@ -19,45 +19,32 @@ class NIDCallStatusObserver: NSObject, CXCallObserverDelegate {
     }
     
     func callObserver(_ callObserver: CXCallObserver, callChanged call: CXCall) {
-        // Outgoing call answered
-        if(call.isOutgoing && call.hasConnected && !call.hasEnded){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.OUTGOING_ANSWERED.rawValue) )
-            NIDLog.d("Outgoing call (answered) observed /could be voice mail")}
+        var status: String
+        var attrs: Attrs
         
-        // Outgoing call ringing
-        else if(call.isOutgoing && !call.hasConnected && !call.hasEnded){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, attrs:Attrs(n: "callMeta", v: CallInProgressMetaData.OUTGOING_RINGING.rawValue) )
-            NIDLog.d("Outgoing call (ringing) observed")}
+        if call.hasEnded {
+            status = CallInProgress.INACTIVE.rawValue
+            attrs = Attrs(n: call.isOutgoing ? CallInProgressMetaData.OUTGOING.rawValue : CallInProgressMetaData.INCOMING.rawValue,
+                          v: CallInProgressMetaData.ENDED.rawValue)
+            
+        } else if call.isOnHold {
+            status = CallInProgress.ACTIVE.rawValue
+            attrs = Attrs(n: call.isOutgoing ? CallInProgressMetaData.OUTGOING.rawValue : CallInProgressMetaData.INCOMING.rawValue,
+                          v: CallInProgressMetaData.ONHOLD.rawValue)
+            
+        } else if call.hasConnected {
+            status = CallInProgress.ACTIVE.rawValue
+            attrs = Attrs(n: call.isOutgoing ? CallInProgressMetaData.OUTGOING.rawValue : CallInProgressMetaData.INCOMING.rawValue,
+                          v: CallInProgressMetaData.ANSWERED.rawValue)
+            
+        } else {
+            status = CallInProgress.INACTIVE.rawValue
+            attrs = Attrs(n: call.isOutgoing ? CallInProgressMetaData.OUTGOING.rawValue : CallInProgressMetaData.INCOMING.rawValue,
+                          v: CallInProgressMetaData.RINGING.rawValue)
+            
+        }
         
-        // Outgoing call ended
-        else if(call.isOutgoing && call.hasEnded){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.OUTGOING_ENDED.rawValue) )
-            NIDLog.d("Outgoing call ended")}
-        
-        // Incoming call ringing
-        else if(!call.isOutgoing && !call.hasConnected && !call.hasEnded){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.INCOMING_RINGING.rawValue) )
-            NIDLog.d("Incoming call (ringing) in progress is observed")}
-        
-        // Incoming call answered
-        else if(!call.isOutgoing && call.hasConnected && !call.hasEnded){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.INCOMING_ANSWERED.rawValue) )
-            NIDLog.d("Incoming call (answered)/voicemail in progress is observed")}
-        
-        // Incoming call ended
-        else if(!call.isOutgoing && call.hasEnded){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.INACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.INCOMING_ENDED.rawValue) )
-            NIDLog.d("Incoming call ended")}
-        
-        // Incoming call on hold
-        else if(!call.isOutgoing && call.isOnHold){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.INCOMING_ONHOLD.rawValue) )
-            NIDLog.d("Incoming call on hold")}
-        
-        // Outgoing call on hold
-        else if(call.isOutgoing && call.isOnHold){
-            UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: CallInProgress.ACTIVE.rawValue, attrs: Attrs(n: "callMeta", v: CallInProgressMetaData.OUTGOING_ONHOLD.rawValue) )
-            NIDLog.d("Outgoing call on hold")}
+        UtilFunctions.captureCallStatusEvent(eventType: NIDEventName.callInProgress, status: status, attrs: attrs)
     }
     
     func startListeningToCallStatus() {

--- a/NeuroID/NIDEvent.swift
+++ b/NeuroID/NIDEvent.swift
@@ -311,6 +311,7 @@ public class NIDEvent: Codable {
     var rts: String?
     var c: Bool?
     var cp: String? // call in progress status
+    var cpm: String?
     var m: String? // part of LOG events
     var level: String? // part of LOG events
 
@@ -409,7 +410,8 @@ public class NIDEvent: Codable {
         sh: CGFloat? = nil,
         sw: CGFloat? = nil,
         metadata: NIDMetadata? = nil,
-        cp: String? = nil
+        cp: String? = nil,
+        cpm: String? = nil
     ) {
         self.type = session.rawValue
         self.f = f
@@ -435,6 +437,7 @@ public class NIDEvent: Codable {
         self.sw = sw
         self.metadata = metadata
         self.cp = cp
+        self.cpm = cpm
     }
 
     /**
@@ -567,6 +570,7 @@ public class NIDEvent: Codable {
         copy.rts = self.rts
         copy.c = self.c
         copy.cp = self.cp
+        copy.cpm = self.cpm
         copy.iswifi = self.iswifi
         copy.isconnected = self.isconnected
 

--- a/NeuroID/NIDEvent.swift
+++ b/NeuroID/NIDEvent.swift
@@ -311,7 +311,6 @@ public class NIDEvent: Codable {
     var rts: String?
     var c: Bool?
     var cp: String? // call in progress status
-    var cpm: String?
     var m: String? // part of LOG events
     var level: String? // part of LOG events
 
@@ -410,8 +409,7 @@ public class NIDEvent: Codable {
         sh: CGFloat? = nil,
         sw: CGFloat? = nil,
         metadata: NIDMetadata? = nil,
-        cp: String? = nil,
-        cpm: String? = nil
+        cp: String? = nil
     ) {
         self.type = session.rawValue
         self.f = f
@@ -437,7 +435,6 @@ public class NIDEvent: Codable {
         self.sw = sw
         self.metadata = metadata
         self.cp = cp
-        self.cpm = cpm
     }
 
     /**
@@ -570,7 +567,6 @@ public class NIDEvent: Codable {
         copy.rts = self.rts
         copy.c = self.c
         copy.cp = self.cp
-        copy.cpm = self.cpm
         copy.iswifi = self.iswifi
         copy.isconnected = self.isconnected
 

--- a/NeuroID/NeuroIDClass/Extensions/NIDLog.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDLog.swift
@@ -179,12 +179,12 @@ func NIDPrintEvent(_ mutableEvent: NIDEvent) {
             contextString = "m=\(mutableEvent.m ?? "")"
         case NIDEventName.advancedDevice.rawValue:
             contextString = "rid=\(mutableEvent.rid ?? "") c=\(mutableEvent.c ?? false) l=\(mutableEvent.l)"
-        case NIDEventName.callInProgress.rawValue: contextString = "cp=\(String(describing: mutableEvent.cp ?? nil))"
+        case NIDEventName.callInProgress.rawValue: contextString = "cp=\(String(describing: mutableEvent.cp ?? nil)) cpm=\(String(describing: mutableEvent.cpm ?? nil))"
         case NIDEventName.mobileMetadataIOS.rawValue:
             contextString = "latong=\(mutableEvent.metadata?.gpsCoordinates.latitude ?? -1), \(mutableEvent.metadata?.gpsCoordinates.longitude ?? -1)"
         case NIDEventName.cadenceReadingAccel.rawValue:
             contextString = "accel=\(mutableEvent.accel?.description ?? "") gyro=\(mutableEvent.gyro?.description ?? "")"
-
+            
         default:
             contextString = ""
     }

--- a/NeuroID/NeuroIDClass/Extensions/NIDLog.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDLog.swift
@@ -179,7 +179,7 @@ func NIDPrintEvent(_ mutableEvent: NIDEvent) {
             contextString = "m=\(mutableEvent.m ?? "")"
         case NIDEventName.advancedDevice.rawValue:
             contextString = "rid=\(mutableEvent.rid ?? "") c=\(mutableEvent.c ?? false) l=\(mutableEvent.l)"
-        case NIDEventName.callInProgress.rawValue: contextString = "cp=\(String(describing: mutableEvent.cp ?? nil)) cpm=\(String(describing: mutableEvent.cpm ?? nil))"
+        case NIDEventName.callInProgress.rawValue: contextString = "cp=\(String(describing: mutableEvent.cp ?? nil)) attrs=[\(attrsString)]"
         case NIDEventName.mobileMetadataIOS.rawValue:
             contextString = "latong=\(mutableEvent.metadata?.gpsCoordinates.latitude ?? -1), \(mutableEvent.metadata?.gpsCoordinates.longitude ?? -1)"
         case NIDEventName.cadenceReadingAccel.rawValue:

--- a/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/NeuroID/TrackerClassExtensions/Utils.swift
@@ -217,11 +217,11 @@ enum UtilFunctions {
     static func captureCallStatusEvent(
         eventType: NIDEventName,
         status: String,
-        attrs: Attrs
+        attrs: [Attrs]
     ) {
         let event = NIDEvent(type: eventType)
         event.cp = status
-        event.attrs = [attrs]
+        event.attrs = attrs
         NeuroID.saveEventToLocalDataStore(event)
     }
 

--- a/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/NeuroID/TrackerClassExtensions/Utils.swift
@@ -217,11 +217,11 @@ enum UtilFunctions {
     static func captureCallStatusEvent(
         eventType: NIDEventName,
         status: String,
-        metadata: String
+        attrs: Attrs
     ) {
         let event = NIDEvent(type: eventType)
         event.cp = status
-        event.cpm = metadata
+        event.attrs = [attrs]
         NeuroID.saveEventToLocalDataStore(event)
     }
 

--- a/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/NeuroID/TrackerClassExtensions/Utils.swift
@@ -216,10 +216,12 @@ enum UtilFunctions {
 
     static func captureCallStatusEvent(
         eventType: NIDEventName,
-        status: String
+        status: String,
+        metadata: String
     ) {
         let event = NIDEvent(type: eventType)
         event.cp = status
+        event.cpm = metadata
         NeuroID.saveEventToLocalDataStore(event)
     }
 


### PR DESCRIPTION
Call metadata would include the call type (incoming/outgoing) and call progress (ringing/answered/ended/onhold). 
Examples of the event:
 ["CALL_IN_PROGRESS - NO_TARGET - cp=Optional(\"false\") attrs=[type=outgoing, progress=ringing]"]
 ["CALL_IN_PROGRESS - NO_TARGET - cp=Optional(\"false\") attrs=[type=outgoing, progress=ended]"]