### PR TITLE
ENG-8323 Session ID origin logic setting refactor

### DIFF
--- a/NeuroID/Constants.swift
+++ b/NeuroID/Constants.swift
@@ -64,6 +64,7 @@ enum Constants: String {
 enum UserIDTypes: String {
     case userID
     case registeredUserID
+    case attemptedLogin
 }
 
 enum SessionOrigin: String {

--- a/NeuroID/Constants.swift
+++ b/NeuroID/Constants.swift
@@ -88,5 +88,4 @@ enum CallInProgressMetaData: String {
     case ENDED = "ended"
     case ONHOLD = "onhold"
     case RINGING = "ringing"
-    
 }

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -323,7 +323,7 @@ extension NeuroID {
 
         // If sessionID is nil, set origin as NID here
         let userGenerated = sessionID != nil
-        
+
         let finalSessionID = sessionID ?? ParamsCreator.generateID()
         if !setUserID(finalSessionID, userGenerated) {
             let res = SessionStartResult(false, "")

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -324,13 +324,10 @@ extension NeuroID {
         }
 
         // If sessionID is nil, set origin as NID here
-        if sessionID == nil {
-            NeuroID.CURRENT_ORIGIN = SessionOrigin.NID_ORIGIN_NID_SET.rawValue
-            NeuroID.CURRENT_ORIGIN_CODE = SessionOrigin.NID_ORIGIN_CODE_NID.rawValue
-        }
-
+        let userGenerated = (sessionID == nil) ? false : true
+        
         let finalSessionID = sessionID ?? ParamsCreator.generateID()
-        if !setUserID(finalSessionID) {
+        if !setUserID(finalSessionID, userGenerated) {
             let res = SessionStartResult(false, "")
 
             completion(res)

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -324,7 +324,7 @@ extension NeuroID {
         }
 
         // If sessionID is nil, set origin as NID here
-        let userGenerated = (sessionID == nil) ? false : true
+        let userGenerated = sessionID != nil
         
         let finalSessionID = sessionID ?? ParamsCreator.generateID()
         if !setUserID(finalSessionID, userGenerated) {

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -217,8 +217,6 @@ extension NeuroID {
     static func clearSessionVariables() {
         NeuroID.userID = nil
         NeuroID.registeredUserID = ""
-        CURRENT_ORIGIN = nil
-        CURRENT_ORIGIN_CODE = nil
 
         NeuroID.linkedSiteID = nil
     }

--- a/NeuroID/NeuroIDClass/Extensions/NIDUser.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDUser.swift
@@ -6,8 +6,15 @@
 //
 
 import Foundation
-
 public extension NeuroID {
+    
+    struct SessionIDOriginalResult{
+        let origin: String
+        let originCode: String
+        let idValue: String
+        let idType: UserIDTypes
+    }
+    
     internal static func validateUserID(_ userId: String) -> Bool {
         // user ids must be from 3 to 100 ascii alhpa numeric characters and can include `.`, `-`, and `_`
         do {
@@ -15,75 +22,62 @@ public extension NeuroID {
             let result = expression.matches(in: userId, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: NSMakeRange(0, userId.count))
             if result.count != 1 {
                 NIDLog.e(NIDError.invalidUserID.rawValue)
-                // If Validation fails send origin event
-                if CURRENT_ORIGIN == nil {
-                    CURRENT_ORIGIN = SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue
-                }
-                CURRENT_ORIGIN_CODE = SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue
-
-                sendOriginEvent(origin: CURRENT_ORIGIN!, originCode: CURRENT_ORIGIN_CODE!, originSessionID: userId)
-
                 return false
             }
         } catch {
             NIDLog.e(NIDError.invalidUserID.rawValue)
-            // Redundant check to ensure CURRENT_ORIGIN is never unsafely accessed
-            if CURRENT_ORIGIN == nil {
-                CURRENT_ORIGIN = SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue
-            }
-            CURRENT_ORIGIN_CODE = SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue
-
-            sendOriginEvent(origin: CURRENT_ORIGIN!, originCode: CURRENT_ORIGIN_CODE!, originSessionID: userId)
             return false
         }
-
         return true
     }
-
-    internal static func setGenericUserID(userId: String, type: UserIDTypes, completion: (Bool) -> Bool) -> Bool {
-        let validID = NeuroID.validateUserID(userId)
-        if !validID { return completion(validID) }
-
-        NIDLog.d(tag: "\(type)", "\(userId)")
-
+    
+    internal static func setGenericUserID(type: UserIDTypes, genericUserID: String, userGenerated: Bool = true ) -> Bool{
+        let validID = validateUserID(genericUserID)
+        
+        let originRes = getOriginResult(idValue: genericUserID, validID: validID, userGenerated: userGenerated, idType: type)
+        sendOriginEvent(originResult: originRes)
+        
+        if(!validID){return false}
+        
+        NIDLog.d(tag: "\(type)", "\(genericUserID)")
+        //    Queue user id event to be sent
         let setUserEvent = NIDEvent(
             sessionEvent: type == .userID ?
-                NIDSessionEventName.setUserId : NIDSessionEventName.setRegisteredUserId
+            NIDSessionEventName.setUserId : NIDSessionEventName.setRegisteredUserId
         )
-
-        setUserEvent.uid = userId
-
+        
+        setUserEvent.uid = genericUserID
+        
         if !NeuroID.isSDKStarted {
             saveQueuedEventToLocalDataStore(setUserEvent)
         } else {
             saveEventToLocalDataStore(setUserEvent)
         }
-
-        return completion(true)
+        return true
     }
-
-    internal static func sendOriginEvent(origin: String, originCode: String, originSessionID: String) {
+    
+    internal static func sendOriginEvent(originResult: SessionIDOriginalResult){
         let sessionIdCodeEvent =
-            NIDEvent(
-                sessionEvent: NIDSessionEventName.setVariable,
-                key: "sessionIdCode",
-                v: originCode
-            )
-
+        NIDEvent(
+            sessionEvent: NIDSessionEventName.setVariable,
+            key: "sessionIdCode",
+            v: originResult.originCode
+        )
+        
         let sessionIdSourceEvent =
-            NIDEvent(
-                sessionEvent: NIDSessionEventName.setVariable,
-                key: "sessionIdSource",
-                v: origin
-            )
-
+        NIDEvent(
+            sessionEvent: NIDSessionEventName.setVariable,
+            key: "sessionIdSource",
+            v: originResult.origin
+        )
+        
         let sessionIdEvent =
-            NIDEvent(
-                sessionEvent: NIDSessionEventName.setVariable,
-                key: "sessionId",
-                v: originSessionID
-            )
-
+        NIDEvent(
+            sessionEvent: NIDSessionEventName.setVariable,
+            key: "sessionId",
+            v: originResult.idValue
+        )
+        
         if !NeuroID.isSDKStarted {
             saveQueuedEventToLocalDataStore(sessionIdCodeEvent)
             saveQueuedEventToLocalDataStore(sessionIdSourceEvent)
@@ -94,61 +88,59 @@ public extension NeuroID {
             saveEventToLocalDataStore(sessionIdEvent)
         }
     }
-
-    static func setUserID(_ userId: String) -> Bool {
-        // Redundant check to ensure CURRENT_ORIGIN is never unsafely accessed
-        if CURRENT_ORIGIN == nil {
-            CURRENT_ORIGIN = SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue
-            CURRENT_ORIGIN_CODE = SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue
+    
+    internal static func getOriginResult(idValue: String,
+                                         validID: Bool,
+                                         userGenerated: Bool,
+                                         idType: UserIDTypes) -> SessionIDOriginalResult{
+        let origin = userGenerated ? SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue : SessionOrigin.NID_ORIGIN_NID_SET.rawValue
+        var originCode = SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue
+        if validID {
+            originCode =  userGenerated ? SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue : SessionOrigin.NID_ORIGIN_CODE_NID.rawValue
         }
-        let res = setGenericUserID(
-            userId: userId, type: .userID
-        ) { success in
-            if success {
-                sendOriginEvent(origin: CURRENT_ORIGIN!, originCode: CURRENT_ORIGIN_CODE!, originSessionID: userId)
-                NeuroID.userID = userId
-            }
-
-            return success
-        }
-
-        return res
+        return SessionIDOriginalResult(origin: origin,originCode: originCode,idValue: idValue,idType: idType)
     }
-
+    
+    static func setUserID(_ userId: String, _ userGenerated: Bool? = true)-> Bool{
+        let validID =  setGenericUserID(type: .userID, genericUserID: userId, userGenerated: userGenerated ?? true)
+        
+        if(!validID){
+            return false
+        }
+        
+        NeuroID.userID = userId
+        return true
+    }
+    
     static func getUserID() -> String {
         return NeuroID.userID ?? ""
     }
-
+    
+    
     static func getRegisteredUserID() -> String {
         return NeuroID.registeredUserID
     }
-
+    
     static func setRegisteredUserID(_ registeredUserID: String) -> Bool {
         if !NeuroID.registeredUserID.isEmpty, registeredUserID != NeuroID.registeredUserID {
             NeuroID.saveEventToLocalDataStore(NIDEvent(level: "warn", m: "Multiple Registered User Id Attempts"))
             NIDLog.e("Multiple Registered UserID Attempt: Only 1 Registered UserID can be set per session")
             return false
         }
-
-        let res = setGenericUserID(
-            userId: registeredUserID, type: .registeredUserID
-        ) { success in
-            if success {
-                NeuroID.registeredUserID = registeredUserID
-            }
-            CURRENT_ORIGIN = SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue
-            CURRENT_ORIGIN_CODE = SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue
-            sendOriginEvent(origin: CURRENT_ORIGIN!, originCode: CURRENT_ORIGIN_CODE!, originSessionID: registeredUserID)
-
-            return success
+        
+        let validID = setGenericUserID(type: .registeredUserID, genericUserID: registeredUserID)
+        
+        if(!validID){
+            return false
         }
-
-        return res
+        
+        NeuroID.registeredUserID = registeredUserID
+        return true
     }
-
+    
     /**
-        This should be called the moment a user trys to login. Returns true always
-        @param {String} [attemptedRegisteredUserId] - an optional identifier for the login
+     This should be called the moment a user trys to login. Returns true always
+     @param {String} [attemptedRegisteredUserId] - an optional identifier for the login
      */
     static func attemptedLogin(_ attemptedRegisteredUserId: String? = nil) -> Bool {
         if NeuroID.validateUserID(attemptedRegisteredUserId ?? "") {

--- a/NeuroID/NeuroIDClass/Extensions/NIDUser.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDUser.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
+
 public extension NeuroID {
-    
-    struct SessionIDOriginalResult{
+    struct SessionIDOriginalResult {
         let origin: String
         let originCode: String
         let idValue: String
@@ -31,23 +31,23 @@ public extension NeuroID {
         return true
     }
     
-    internal static func setGenericUserID(type: UserIDTypes, genericUserID: String, userGenerated: Bool = true ) -> Bool{
+    internal static func setGenericUserID(type: UserIDTypes, genericUserID: String, userGenerated: Bool = true) -> Bool {
         let validID = validateUserID(genericUserID)
         
         let originRes = getOriginResult(idValue: genericUserID, validID: validID, userGenerated: userGenerated, idType: type)
         sendOriginEvent(originResult: originRes)
         
-        if(!validID){return false}
+        if !validID { return false }
         
         NIDLog.d(tag: "\(type)", "\(genericUserID)")
         //    Queue user id event to be sent
         var setUserEvent: NIDEvent
-        if (type == .attemptedLogin){
+        if type == .attemptedLogin {
             setUserEvent = NIDEvent(uid: genericUserID)
-        }else{
+        } else {
             setUserEvent = NIDEvent(
                 sessionEvent: type == .userID ?
-                NIDSessionEventName.setUserId : NIDSessionEventName.setRegisteredUserId
+                    NIDSessionEventName.setUserId : NIDSessionEventName.setRegisteredUserId
             )
             setUserEvent.uid = genericUserID
         }
@@ -60,34 +60,34 @@ public extension NeuroID {
         return true
     }
     
-    internal static func sendOriginEvent(originResult: SessionIDOriginalResult){
+    internal static func sendOriginEvent(originResult: SessionIDOriginalResult) {
         let sessionIdCodeEvent =
-        NIDEvent(
-            sessionEvent: NIDSessionEventName.setVariable,
-            key: "sessionIdCode",
-            v: originResult.originCode
-        )
+            NIDEvent(
+                sessionEvent: NIDSessionEventName.setVariable,
+                key: "sessionIdCode",
+                v: originResult.originCode
+            )
         
         let sessionIdSourceEvent =
-        NIDEvent(
-            sessionEvent: NIDSessionEventName.setVariable,
-            key: "sessionIdSource",
-            v: originResult.origin
-        )
+            NIDEvent(
+                sessionEvent: NIDSessionEventName.setVariable,
+                key: "sessionIdSource",
+                v: originResult.origin
+            )
         
         let sessionIdEvent =
-        NIDEvent(
-            sessionEvent: NIDSessionEventName.setVariable,
-            key: "sessionId",
-            v:"\(originResult.idValue)"
-        )
+            NIDEvent(
+                sessionEvent: NIDSessionEventName.setVariable,
+                key: "sessionId",
+                v: "\(originResult.idValue)"
+            )
         
         let sessionIdTypeEvent =
-        NIDEvent(
-            sessionEvent: NIDSessionEventName.setVariable,
-            key: "sessionIdType",
-            v: originResult.idType.rawValue
-        )
+            NIDEvent(
+                sessionEvent: NIDSessionEventName.setVariable,
+                key: "sessionIdType",
+                v: originResult.idType.rawValue
+            )
         if !NeuroID.isSDKStarted {
             saveQueuedEventToLocalDataStore(sessionIdCodeEvent)
             saveQueuedEventToLocalDataStore(sessionIdSourceEvent)
@@ -104,23 +104,24 @@ public extension NeuroID {
     internal static func getOriginResult(idValue: String,
                                          validID: Bool,
                                          userGenerated: Bool,
-                                         idType: UserIDTypes) -> SessionIDOriginalResult{
+                                         idType: UserIDTypes) -> SessionIDOriginalResult
+    {
         let origin = userGenerated ? SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue : SessionOrigin.NID_ORIGIN_NID_SET.rawValue
         var originCode = SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue
         if validID {
-            originCode =  userGenerated ? SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue : SessionOrigin.NID_ORIGIN_CODE_NID.rawValue
+            originCode = userGenerated ? SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue : SessionOrigin.NID_ORIGIN_CODE_NID.rawValue
         }
-        return SessionIDOriginalResult(origin: origin,originCode: originCode,idValue: idValue,idType: idType)
+        return SessionIDOriginalResult(origin: origin, originCode: originCode, idValue: idValue, idType: idType)
     }
     
-    static func setUserID(_ userId: String)->Bool{
+    static func setUserID(_ userId: String) -> Bool {
         return setUserID(userId, true)
     }
     
-    internal static func setUserID(_ userId: String, _ userGenerated: Bool)-> Bool{
-        let validID =  setGenericUserID(type: .userID, genericUserID: userId, userGenerated: userGenerated)
+    internal static func setUserID(_ userId: String, _ userGenerated: Bool) -> Bool {
+        let validID = setGenericUserID(type: .userID, genericUserID: userId, userGenerated: userGenerated)
         
-        if(!validID){
+        if !validID {
             return false
         }
         
@@ -131,7 +132,6 @@ public extension NeuroID {
     static func getUserID() -> String {
         return NeuroID.userID ?? ""
     }
-    
     
     static func getRegisteredUserID() -> String {
         return NeuroID.registeredUserID
@@ -146,7 +146,7 @@ public extension NeuroID {
         
         let validID = setGenericUserID(type: .registeredUserID, genericUserID: registeredUserID)
         
-        if(!validID){
+        if !validID {
             return false
         }
         
@@ -161,14 +161,13 @@ public extension NeuroID {
     static func attemptedLogin(_ attemptedRegisteredUserId: String? = nil) -> Bool {
         let captured = setGenericUserID(type: .attemptedLogin, genericUserID: attemptedRegisteredUserId ?? "scrubbed-id-failed-validation", userGenerated: attemptedRegisteredUserId != nil)
         
-        if(!captured){
+        if !captured {
             if !NeuroID.isSDKStarted {
                 saveQueuedEventToLocalDataStore(NIDEvent(uid: "scrubbed-id-failed-validation"))
-            }else{ 
-                saveEventToLocalDataStore(NIDEvent(uid: "scrubbed-id-failed-validation" ))}
-            
+            } else {
+                saveEventToLocalDataStore(NIDEvent(uid: "scrubbed-id-failed-validation"))
+            }
         }
         return true
-        
     }
 }

--- a/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/NeuroID/NeuroIDClass/NeuroID.swift
@@ -74,9 +74,8 @@ public class NeuroID: NSObject {
     static var lowMemory: Bool = false
 
     static var isAdvancedDevice: Bool = false
-    
-    static var packetNumber : Int32 = 0
-    
+
+    static var packetNumber: Int32 = 0
 
     // MARK: - Setup
 

--- a/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/NeuroID/NeuroIDClass/NeuroID.swift
@@ -18,8 +18,6 @@ import WebKit
 
 public class NeuroID: NSObject {
     static let SEND_INTERVAL: Double = 5
-    static var CURRENT_ORIGIN: String?
-    static var CURRENT_ORIGIN_CODE: String?
 
     static var clientKey: String?
     static var siteID: String?

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -443,34 +443,24 @@ class NIDNewSessionTests: XCTestCase {
         clearOutDataStore()
     }
     
-    func assertStoredEventTypeAndCount(type: String, count: Int) {
+    func assertStoredEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
         
         assert(validEvent.count == count)
-        assert(validEvent[0].type == type)
+        if(!skipType!){
+            assert(validEvent[0].type == type)
+        }
     }
     
-    func assertQueuedEventTypeAndCount(type: String, count: Int) {
+    func assertQueuedEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
         let allEvents = DataStore.queuedEvents
         let validEvent = allEvents.filter { $0.type == type }
         
         assert(validEvent.count == count)
-        assert(validEvent[0].type == type)
-    }
-    
-    func assertQueuedEventCount(type: String, count: Int) {
-        let allEvents = DataStore.queuedEvents
-        let validEvent = allEvents.filter { $0.type == type }
-        
-        assert(validEvent.count == count)
-    }
-    
-    func assertStoredEventCount(type: String, count: Int) {
-        let allEvents = DataStore.getAllEvents()
-        let validEvent = allEvents.filter { $0.type == type }
-        
-        assert(validEvent.count == count)
+        if(!skipType!){
+            assert(validEvent[0].type == type)
+        }
     }
     
     func assertStoredEventOrigin(type: String, origin: String, originCode: String) {
@@ -595,11 +585,13 @@ class NIDNewSessionTests: XCTestCase {
     
     func test_startSession_failure_userID() {
         NeuroID.sendCollectionWorkItem = nil
-        
         NeuroID.startSession("MY bad -.-. id") {
             sessionRes in
             self.assertSessionNotStartedTests(sessionRes)
         }
+        assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
+        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertQueuedEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue)
     }
     
     func test_pauseCollection() {
@@ -849,34 +841,25 @@ class NIDUserTests: XCTestCase {
         clearOutDataStore()
     }
     
-    func assertStoredEventTypeAndCount(type: String, count: Int) {
+    func assertStoredEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
         
         assert(validEvent.count == count)
-        assert(validEvent[0].type == type)
+        if(!skipType!){
+            assert(validEvent[0].type == type)
+        }
+        
     }
     
-    func assertQueuedEventCount(type: String, count: Int) {
+    func assertQueuedEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
         let allEvents = DataStore.queuedEvents
         let validEvent = allEvents.filter { $0.type == type }
         
         assert(validEvent.count == count)
-    }
-    
-    func assertStoredEventCount(type: String, count: Int) {
-        let allEvents = DataStore.getAllEvents()
-        let validEvent = allEvents.filter { $0.type == type }
-        
-        assert(validEvent.count == count)
-    }
-    
-    func assertQueuedEventTypeAndCount(type: String, count: Int) {
-        let allEvents = DataStore.queuedEvents
-        let validEvent = allEvents.filter { $0.type == type }
-        
-        assert(validEvent.count == count)
-        assert(validEvent[0].type == type)
+        if(!skipType!){
+            assert(validEvent[0].type == type)
+        }
     }
     
     func assertStoredEventOrigin(type: String, origin: String, originCode: String) {
@@ -992,7 +975,7 @@ class NIDUserTests: XCTestCase {
         let result = NeuroID.setGenericUserID(type: .userID, genericUserID: expectedValue, userGenerated: true)
         
         assert(result == false)
-        assertStoredEventCount(type: "SET_USER_ID", count: 0)
+        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
         assertStoredEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue)
     }
@@ -1006,7 +989,7 @@ class NIDUserTests: XCTestCase {
         
         assert(result == false)
         assert(DataStore.events.count == 0)
-        assertQueuedEventCount(type: "SET_USER_ID", count: 0)
+        assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
         assertQueuedEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue)
     }

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -463,21 +463,9 @@ class NIDNewSessionTests: XCTestCase {
         }
     }
     
-    func assertStoredEventOrigin(type: String, origin: String, originCode: String) {
-        let allEvents = DataStore.getAllEvents()
-        let validEvents = allEvents.filter { $0.type == type }
+    func assertDatastoreEventOrigin(type: String, origin: String, originCode: String, queued: Bool) {
         
-        let originEvent = validEvents.filter { $0.key == "sessionIdSource"}
-        assert(originEvent.count == 1)
-        assert(originEvent[0].v == origin)
-        
-        let originCodeEvent = validEvents.filter { $0.key == "sessionIdCode"}
-        assert(originCodeEvent.count == 1)
-        assert(originCodeEvent[0].v == originCode)
-    }
-    
-    func assertQueuedEventOrigin(type: String, origin: String, originCode: String) {
-        let allEvents = DataStore.queuedEvents
+        let allEvents = queued ? DataStore.queuedEvents : DataStore.getAllEvents()
         let validEvents = allEvents.filter { $0.type == type }
         
         let originEvent = validEvents.filter { $0.key == "sessionIdSource"}
@@ -532,7 +520,7 @@ class NIDNewSessionTests: XCTestCase {
         // TODO-How are events showing up in Datastore and not Queue
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertStoredEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
     }
     
     func test_startSession_success_no_id() {
@@ -547,7 +535,7 @@ class NIDNewSessionTests: XCTestCase {
         // TODO-How are events showing up in Datastore and not Queue
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertStoredEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
     }
     
     func test_startSession_success_no_id_sdk_started() {
@@ -561,7 +549,7 @@ class NIDNewSessionTests: XCTestCase {
         }
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertStoredEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
     }
     
     func test_startSession_success_id_sdk_started() {
@@ -575,7 +563,7 @@ class NIDNewSessionTests: XCTestCase {
         }
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertStoredEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
     }
     
     func test_startSession_failure_clientKey() {
@@ -595,7 +583,7 @@ class NIDNewSessionTests: XCTestCase {
         }
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertQueuedEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: true)
     }
     
     func test_pauseCollection() {
@@ -866,21 +854,9 @@ class NIDUserTests: XCTestCase {
         }
     }
     
-    func assertStoredEventOrigin(type: String, origin: String, originCode: String) {
-        let allEvents = DataStore.getAllEvents()
-        let validEvents = allEvents.filter { $0.type == type }
+    func assertDatastoreEventOrigin(type: String, origin: String, originCode: String, queued: Bool) {
         
-        let originEvent = validEvents.filter { $0.key == "sessionIdSource"}
-        assert(originEvent.count == 1)
-        assert(originEvent[0].v == origin)
-        
-        let originCodeEvent = validEvents.filter { $0.key == "sessionIdCode"}
-        assert(originCodeEvent.count == 1)
-        assert(originCodeEvent[0].v == originCode)
-    }
-    
-    func assertQueuedEventOrigin(type: String, origin: String, originCode: String) {
-        let allEvents = DataStore.queuedEvents
+        let allEvents = queued ? DataStore.queuedEvents : DataStore.getAllEvents()
         let validEvents = allEvents.filter { $0.type == type }
         
         let originEvent = validEvents.filter { $0.key == "sessionIdSource"}
@@ -981,7 +957,7 @@ class NIDUserTests: XCTestCase {
         assert(result == false)
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertStoredEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: false)
     }
     
     func test_setGenericUserID_invalid_id_queued() {
@@ -995,7 +971,7 @@ class NIDUserTests: XCTestCase {
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertQueuedEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: true)
     }
     
     func test_setUserID_started_customer_origin() {
@@ -1013,7 +989,7 @@ class NIDUserTests: XCTestCase {
         
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertStoredEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
         
         assert(DataStore.queuedEvents.count == 0)
     }
@@ -1035,7 +1011,7 @@ class NIDUserTests: XCTestCase {
         //        assert(DataStore.events.count == 0) "NETWORK_STATE" event present
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertQueuedEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: true)
     }
     
     func test_setUserID_started_nid_origin() {
@@ -1053,7 +1029,7 @@ class NIDUserTests: XCTestCase {
         
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertStoredEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
         
         assert(DataStore.queuedEvents.count == 0)
     }
@@ -1075,7 +1051,7 @@ class NIDUserTests: XCTestCase {
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertQueuedEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: true)
     }
     
     func test_getUserID_objectLevel() {
@@ -1133,7 +1109,7 @@ class NIDUserTests: XCTestCase {
         
         assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertStoredEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
         assert(DataStore.queuedEvents.count == 0)
         
         NeuroID.registeredUserID = ""
@@ -1156,7 +1132,7 @@ class NIDUserTests: XCTestCase {
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        assertQueuedEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue)
+        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: true)
         NeuroID.registeredUserID = ""
     }
     

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -448,7 +448,7 @@ class NIDNewSessionTests: XCTestCase {
         let validEvent = allEvents.filter { $0.type == type }
         
         assert(validEvent.count == count)
-        if(!skipType!){
+        if !skipType! {
             assert(validEvent[0].type == type)
         }
     }
@@ -458,21 +458,20 @@ class NIDNewSessionTests: XCTestCase {
         let validEvent = allEvents.filter { $0.type == type }
         
         assert(validEvent.count == count)
-        if(!skipType!){
+        if !skipType! {
             assert(validEvent[0].type == type)
         }
     }
     
     func assertDatastoreEventOrigin(type: String, origin: String, originCode: String, queued: Bool) {
-        
         let allEvents = queued ? DataStore.queuedEvents : DataStore.getAllEvents()
         let validEvents = allEvents.filter { $0.type == type }
         
-        let originEvent = validEvents.filter { $0.key == "sessionIdSource"}
+        let originEvent = validEvents.filter { $0.key == "sessionIdSource" }
         assert(originEvent.count == 1)
         assert(originEvent[0].v == origin)
         
-        let originCodeEvent = validEvents.filter { $0.key == "sessionIdCode"}
+        let originCodeEvent = validEvents.filter { $0.key == "sessionIdCode" }
         assert(originCodeEvent.count == 1)
         assert(originCodeEvent[0].v == originCode)
     }
@@ -838,10 +837,9 @@ class NIDUserTests: XCTestCase {
         let validEvent = allEvents.filter { $0.type == type }
         
         assert(validEvent.count == count)
-        if(!skipType!){
+        if !skipType! {
             assert(validEvent[0].type == type)
         }
-        
     }
     
     func assertQueuedEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
@@ -849,21 +847,20 @@ class NIDUserTests: XCTestCase {
         let validEvent = allEvents.filter { $0.type == type }
         
         assert(validEvent.count == count)
-        if(!skipType!){
+        if !skipType! {
             assert(validEvent[0].type == type)
         }
     }
     
     func assertDatastoreEventOrigin(type: String, origin: String, originCode: String, queued: Bool) {
-        
         let allEvents = queued ? DataStore.queuedEvents : DataStore.getAllEvents()
         let validEvents = allEvents.filter { $0.type == type }
         
-        let originEvent = validEvents.filter { $0.key == "sessionIdSource"}
+        let originEvent = validEvents.filter { $0.key == "sessionIdSource" }
         assert(originEvent.count == 1)
         assert(originEvent[0].v == origin)
         
-        let originCodeEvent = validEvents.filter { $0.key == "sessionIdCode"}
+        let originCodeEvent = validEvents.filter { $0.key == "sessionIdCode" }
         assert(originCodeEvent.count == 1)
         assert(originCodeEvent[0].v == originCode)
     }

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -11,34 +11,34 @@ import XCTest
 
 class NeuroIDClassTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-
+    
     // Keys for storage:
     let localStorageNIDStopAll = Constants.storageLocalNIDStopAllKey.rawValue
     let clientKeyKey = Constants.storageClientKey.rawValue
     let tabIdKey = Constants.storageTabIDKey.rawValue
-
+    
     let mockService = MockDeviceSignalService()
-
+    
     func clearOutDataStore() {
         let _ = DataStore.getAndRemoveAllEvents()
     }
-
+    
     override func setUpWithError() throws {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-
+    
     override func setUp() {
         UserDefaults.standard.removeObject(forKey: Constants.storageAdvancedDeviceKey.rawValue)
         mockService.mockResult = .success(("mock", Double(Int.random(in: 0..<3000))))
     }
-
+    
     override func tearDown() {
         _ = NeuroID.stop()
-
+        
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-
+    
     func test_getAdvDeviceLatency() {
         let mockService = MockDeviceSignalService()
         NeuroID.deviceSignalService = mockService
@@ -47,53 +47,53 @@ class NeuroIDClassTests: XCTestCase {
         mockService.mockResult = .success(("empty mock result. Can be filled with anything", randomTimeInMilliseconds))
         NeuroID.start(true) { _ in
             let allEvents = DataStore.getAllEvents()
-
+            
             let validEvent = allEvents.filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
             XCTAssertTrue(validEvent.count == 1)
         }
     }
-
+    
     func assertDataStoreCount(count: Int) {
         let allEvents = DataStore.getAllEvents()
         assert(allEvents.count == count)
     }
-
+    
     func assertStoredEventCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-
+        
         assert(validEvent.count == count)
     }
-
+    
     func assertStoredEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-
+        
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-
+    
     func test_configure_success() {
         clearOutDataStore()
         // remove things configured in setup
         NeuroID.clientKey = nil
         UserDefaults.standard.setValue(nil, forKey: clientKeyKey)
         UserDefaults.standard.setValue("testTabId", forKey: tabIdKey)
-
+        
         let configured = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
         assert(configured)
-
+        
         let clientKeyValue = UserDefaults.standard.string(forKey: clientKeyKey)
         assert(clientKeyValue == clientKey)
-
+        
         let tabIdValue = UserDefaults.standard.string(forKey: tabIdKey)
         assert(tabIdValue == nil)
-
+        
         assertStoredEventCount(type: "CREATE_SESSION", count: 0)
-
+        
         assert(NeuroID.environment == "\(Constants.environmentLive.rawValue)")
     }
-
+    
     func test_configure_invalidKey() {
         clearOutDataStore()
         // remove things configured in setup
@@ -101,30 +101,30 @@ class NeuroIDClassTests: XCTestCase {
         NeuroID.clientKey = nil
         UserDefaults.standard.setValue(nil, forKey: clientKeyKey)
         UserDefaults.standard.setValue("testTabId", forKey: tabIdKey)
-
+        
         let configured = NeuroID.configure(clientKey: "invalid_key", isAdvancedDevice: false)
         assert(configured == false)
-
+        
         let clientKeyValue = UserDefaults.standard.string(forKey: clientKeyKey)
         assert(clientKeyValue == nil)
-
+        
         let tabIdValue = UserDefaults.standard.string(forKey: tabIdKey)
         assert(tabIdValue == "testTabId")
-
+        
         assertStoredEventCount(type: "CREATE_SESSION", count: 0)
-
+        
         assert(NeuroID.environment == "\(Constants.environmentTest.rawValue)")
     }
-
+    
     func test_start_failure() {
         tearDown()
         NeuroID._isSDKStarted = false
         NeuroID.clientKey = nil
-
+        
         // pre tests
         assert(!NeuroID.isSDKStarted)
         assert(NeuroID.clientKey == nil)
-
+        
         // action
         NeuroID.start { started in
             assert(!started)
@@ -132,14 +132,14 @@ class NeuroIDClassTests: XCTestCase {
             assert(!NeuroID.isSDKStarted)
         }
     }
-
+    
     func test_start_success() {
         tearDown()
         NeuroID._isSDKStarted = false
-
+        
         // pre tests
         assert(!NeuroID.isSDKStarted)
-
+        
         // action
         NeuroID.start { started in
             // post action test
@@ -150,25 +150,25 @@ class NeuroIDClassTests: XCTestCase {
             self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 1)
         }
     }
-
+    
     func test_start_success_queuedEvent() {
         _ = NeuroID.stop()
         let setUserIDRes = NeuroID.setUserID("test_uid")
-
+        
         assert(setUserIDRes)
-
+        
         NeuroID._isSDKStarted = false
-
+        
         // pre tests
         assert(!NeuroID.isSDKStarted)
-
+        
         // action
         NeuroID.start { started in
-
+            
             // post action test
             assert(started)
             assert(NeuroID.isSDKStarted)
-
+            
             assert(DataStore.events.count == 6)
             self.assertStoredEventCount(type: "CREATE_SESSION", count: 1)
             self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 1)
@@ -176,128 +176,128 @@ class NeuroIDClassTests: XCTestCase {
             self.assertStoredEventCount(type: "SET_VARIABLE", count: 3)
         }
     }
-
+    
     func test_stop() {
         NeuroID._isSDKStarted = true
         assert(NeuroID.isSDKStarted)
-
+        
         let stopped = NeuroID.stop()
         assert(stopped)
         assert(!NeuroID.isSDKStarted)
     }
-
+    
     func test_getSDKVersion() {
         let expectedValue = ParamsCreator.getSDKVersion()
-
+        
         let value = NeuroID.getSDKVersion()
-
+        
         assert(value == expectedValue)
     }
 }
 
 class NIDRegistrationTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-
+    
     func clearOutDataStore() {
         DataStore.removeSentEvents()
     }
-
+    
     override func setUpWithError() throws {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-
+    
     override func setUp() {
         NeuroID._isSDKStarted = true
     }
-
+    
     override func tearDown() {
         _ = NeuroID.stop()
-
+        
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-
+    
     func assertDataStoreCount(count: Int) {
         let allEvents = DataStore.getAllEvents()
         assert(allEvents.count == count)
     }
-
+    
     func assertStoredEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-
+        
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-
+    
     func test_excludeViewByTestID() {
         clearOutDataStore()
         NeuroID.excludedViewsTestIDs = []
         let expectedValue = "testScreenName"
-
+        
         NeuroID.excludeViewByTestID(excludedView: expectedValue)
-
+        
         let contains = NeuroID.excludedViewsTestIDs.contains(where: { $0 == expectedValue })
         assert(contains)
-
+        
         assert(NeuroID.excludedViewsTestIDs.count == 1)
     }
-
+    
     func test_manuallyRegisterTarget_valid_type() {
         clearOutDataStore()
         let uiView = UITextField()
         uiView.id = "wow"
-
+        
         NeuroID.manuallyRegisterTarget(view: uiView)
-
+        
         assertStoredEventTypeAndCount(type: "REGISTER_TARGET", count: 1)
-
+        
         let allEvents = DataStore.getAllEvents()
         let validEvents = allEvents.filter { $0.type == "REGISTER_TARGET" }
         assert(validEvents[0].tgs == "wow")
         assert(validEvents[0].et == "UITextField::UITextField")
     }
-
+    
     func test_manuallyRegisterTarget_invalid_type() {
         clearOutDataStore()
         let uiView = UIView()
-
+        
         NeuroID.manuallyRegisterTarget(view: uiView)
-
+        
         assertDataStoreCount(count: 0)
     }
-
+    
     func test_manuallyRegisterRNTarget() {
         clearOutDataStore()
-
+        
         let event = NeuroID.manuallyRegisterRNTarget(
             id: "test",
             className: "testClassName",
             screenName: "testScreenName",
             placeHolder: "testPlaceholder"
         )
-
+        
         assert(event.tgs == "test")
         assert(event.et == "testClassName")
         assert(event.etn == "INPUT")
-
+        
         assertStoredEventTypeAndCount(type: "REGISTER_TARGET", count: 1)
     }
-
+    
     func test_setCustomVariable() {
         clearOutDataStore()
         let event = NeuroID.setCustomVariable(key: "t", v: "v")
-
+        
         XCTAssertTrue(event.type == NIDSessionEventName.setVariable.rawValue)
         XCTAssertTrue(event.key == "t")
         XCTAssertTrue(event.v == "v")
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 1)
     }
-
+    
     func test_setVariable() {
         clearOutDataStore()
         let event = NeuroID.setVariable(key: "t", value: "v")
-
+        
         XCTAssertTrue(event.type == NIDSessionEventName.setVariable.rawValue)
         XCTAssertTrue(event.key == "t")
         XCTAssertTrue(event.v == "v")
@@ -307,87 +307,87 @@ class NIDRegistrationTests: XCTestCase {
 
 class NIDSessionTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-
+    
     let sessionIdKey = Constants.storageSessionIDKey.rawValue
     let clientIdKey = Constants.storageClientIDKey.rawValue
-
+    
     func clearOutDataStore() {
         DataStore.removeSentEvents()
     }
-
+    
     override func setUpWithError() throws {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-
+    
     override func setUp() {
         NeuroID._isSDKStarted = true
     }
-
+    
     override func tearDown() {
         _ = NeuroID.stop()
-
+        
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-
+    
     func assertStoredEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-
+        
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-
+    
     func test_clearStoredSessionID() {
         UserDefaults.standard.set("session", forKey: sessionIdKey)
         UserDefaults.standard.set("client", forKey: clientIdKey)
-
+        
         NeuroID.clearStoredSessionID()
-
+        
         let session = UserDefaults.standard.string(forKey: sessionIdKey)
         let client = UserDefaults.standard.string(forKey: clientIdKey)
-
+        
         assert(session == nil)
         assert(client != nil)
     }
-
+    
     func test_getSessionID() {
         let expectedValue = "session"
         UserDefaults.standard.set(expectedValue, forKey: sessionIdKey)
-
+        
         let value = NeuroID.getSessionID()
-
+        
         assert(value == expectedValue)
     }
-
+    
     func test_getSessionID_existing() {
         let expectedValue = "test_sid"
         UserDefaults.standard.set(expectedValue, forKey: sessionIdKey)
-
+        
         let value = NeuroID.getSessionID()
-
+        
         assert(value == expectedValue)
     }
-
+    
     func test_getSessionID_random() {
         UserDefaults.standard.set(nil, forKey: sessionIdKey)
-
+        
         let value = NeuroID.getSessionID()
-
+        
         assert(value != "")
         assert(value.count == 36)
     }
-
+    
     func test_createSession() {
         clearOutDataStore()
         DataStore.removeSentEvents()
-
+        
         NeuroID.createSession()
-
+        
         assertStoredEventTypeAndCount(type: "CREATE_SESSION", count: 1)
         assertStoredEventTypeAndCount(type: "MOBILE_METADATA_IOS", count: 1)
     }
-
+    
     func test_closeSession() {
         clearOutDataStore()
         do {
@@ -397,228 +397,227 @@ class NIDSessionTests: XCTestCase {
             NIDLog.e("Threw on Close Session that shouldn't")
             XCTFail()
         }
-
-//        assertStoredEventTypeAndCount(type: "CLOSE_SESSION", count: 1)
+        
+        //        assertStoredEventTypeAndCount(type: "CLOSE_SESSION", count: 1)
     }
-
+    
     func test_closeSession_whenStopped() {
         _ = NeuroID.stop()
         clearOutDataStore()
-
+        
         XCTAssertThrowsError(
             try NeuroID.closeSession(),
             "Close Session throws an error when SDK is already stopped"
         )
     }
-
+    
     func test_captureMobileMetadata() {
         clearOutDataStore()
-
+        
         NeuroID.captureMobileMetadata()
-
+        
         assertStoredEventTypeAndCount(type: NIDSessionEventName.mobileMetadataIOS.rawValue, count: 1)
     }
 }
 
 class NIDNewSessionTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-
+    
     let sessionIdKey = Constants.storageSessionIDKey.rawValue
     let clientIdKey = Constants.storageClientIDKey.rawValue
-
+    
     func clearOutDataStore() {
         DataStore.removeSentEvents()
         _ = DataStore.getAndRemoveAllQueuedEvents()
     }
-
+    
     override func setUpWithError() throws {
         NeuroID.configService = MockConfigService()
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-
+    
     override func tearDown() {
         _ = NeuroID.stop()
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-
+    
     func assertStoredEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-
+        
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-
+    
     func assertQueuedEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.queuedEvents
         let validEvent = allEvents.filter { $0.type == type }
-
+        
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-
+    
     func assertSessionStartedTests(_ sessionRes: SessionStartResult) {
         assert(sessionRes.started)
         assert(NeuroID._isSDKStarted)
         assert(NeuroID.sendCollectionWorkItem == nil) // In real world it would != nil but because of tests we don't want to trigger a re-occuring event
-
+        
         assertStoredEventTypeAndCount(type: NIDSessionEventName.createSession.rawValue, count: 1)
         assertStoredEventTypeAndCount(type: NIDSessionEventName.mobileMetadataIOS.rawValue, count: 1)
         assertStoredEventTypeAndCount(type: NIDSessionEventName.setUserId.rawValue, count: 1)
         assert(DataStore.queuedEvents.isEmpty)
     }
-
+    
     func assertSessionNotStartedTests(_ sessionRes: SessionStartResult) {
         assert(!sessionRes.started)
         assert(sessionRes.sessionID == "")
         assert(!NeuroID._isSDKStarted)
         assert(NeuroID.sendCollectionWorkItem == nil) // In real world it would != nil but because of tests we don't want to trigger a re-occuring event
     }
-
+    
     //    clearSessionVariables
     func test_clearSessionVariables() {
         NeuroID.userID = "myUserID"
         NeuroID.registeredUserID = "myRegisteredUserID"
         NeuroID.linkedSiteID = "mySite"
-
+        
         NeuroID.clearSessionVariables()
-
+        
         assert(NeuroID.userID == nil)
         assert(NeuroID.registeredUserID == "")
         assert(NeuroID.linkedSiteID == nil)
     }
-
+    
     func test_startSession_success_id() {
         NeuroID.userID = nil
         NeuroID._isSDKStarted = false
-
+        
         let expectedValue = "mySessionID"
         NeuroID.startSession(expectedValue) { sessionRes in
             self.assertSessionStartedTests(sessionRes)
-            assert(NeuroID.CURRENT_ORIGIN == SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue)
             assert(expectedValue == sessionRes.sessionID)
         }
     }
-
+    
     func test_startSession_success_no_id() {
         NeuroID.userID = nil
         NeuroID._isSDKStarted = false
-
+        
         let expectedValue = "mySessionID"
         NeuroID.startSession { sessionRes in
             self.assertSessionStartedTests(sessionRes)
             assert(expectedValue != sessionRes.sessionID)
         }
     }
-
+    
     func test_startSession_failure_clientKey() {
         NeuroID.clientKey = nil
         NeuroID.sendCollectionWorkItem = nil
-
+        
         NeuroID.startSession { sessionRes in
             self.assertSessionNotStartedTests(sessionRes)
         }
     }
-
+    
     func test_startSession_failure_userID() {
         NeuroID.sendCollectionWorkItem = nil
-
+        
         NeuroID.startSession("MY bad -.-. id") {
             sessionRes in
             self.assertSessionNotStartedTests(sessionRes)
         }
     }
-
+    
     func test_pauseCollection() {
         NeuroID._isSDKStarted = true
         NeuroID.sendCollectionWorkItem = DispatchWorkItem {}
-
+        
         NeuroID.pauseCollection()
-
+        
         assert(!NeuroID._isSDKStarted)
         assert(NeuroID.sendCollectionWorkItem == nil)
     }
-
+    
     func test_resumeCollection() {
         NeuroID._isSDKStarted = false
         NeuroID.userID = "temp"
         NeuroID.sendCollectionWorkItem = nil
-
+        
         NeuroID.resumeCollection()
-
+        
         assert(NeuroID._isSDKStarted)
         assert(NeuroID.sendCollectionWorkItem != nil)
     }
-
+    
     func test_willNotResumeCollectionIfNotStarted() {
         NeuroID._isSDKStarted = false
         NeuroID.userID = nil
         NeuroID.resumeCollection()
-
+        
         assert(!NeuroID._isSDKStarted)
     }
-
+    
     func test_stopSession() {
         let stopped = NeuroID.stopSession()
-
+        
         assert(stopped)
     }
-
+    
     func test_startAppFlow_valid_site() {
         let mySite = "form_thing123"
         NeuroID._isSDKStarted = true
         NeuroID.linkedSiteID = nil
-
+        
         NeuroID.startAppFlow(siteID: mySite) { started in
             assert(started.started)
             assert(NeuroID.linkedSiteID == mySite)
-
+            
             NeuroID._isSDKStarted = false
             NeuroID.linkedSiteID = nil
         }
     }
-
+    
     func test_startAppFlow_invalid_site() {
         let mySite = "mySite"
         NeuroID._isSDKStarted = true
         NeuroID.linkedSiteID = nil
-
+        
         NeuroID.startAppFlow(siteID: mySite) { started in
             assert(!started.started)
             assert(NeuroID.linkedSiteID == nil)
-
+            
             NeuroID._isSDKStarted = false
         }
     }
-
+    
     func test_clearSendOldFlowEvents_not_sampled() {
         DataStore.events.append(NIDEvent(rawType: "test"))
         let mockSampling = NIDSamplingService()
         mockSampling._isSessionFlowSampled = false
         NeuroID.samplingService = mockSampling
-
+        
         NeuroID.clearSendOldFlowEvents {
             assert(DataStore.events.count == 0)
-
+            
             NeuroID._isSDKStarted = false
         }
     }
-
+    
     func test_clearSendOldFlowEvents_sampled() {
         DataStore.events.append(NIDEvent(rawType: "test"))
         let mockSampling = NIDSamplingService()
         mockSampling._isSessionFlowSampled = true
         NeuroID.samplingService = mockSampling
-
+        
         let mockNetwork = NIDNetworkServiceTestImpl()
         NeuroID.networkService = mockNetwork
-
+        
         NeuroID._isSDKStarted = true
-
+        
         NeuroID.clearSendOldFlowEvents {
             assert(DataStore.events.count == 0)
-
+            
             NeuroID._isSDKStarted = false
         }
     }
@@ -626,127 +625,127 @@ class NIDNewSessionTests: XCTestCase {
 
 class NIDFormTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-
+    
     let sessionIdKey = Constants.storageSessionIDKey.rawValue
     let clientIdKey = Constants.storageClientIDKey.rawValue
-
+    
     func clearOutDataStore() {
         DataStore.removeSentEvents()
     }
-
+    
     override func setUpWithError() throws {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-
+    
     override func setUp() {
         NeuroID._isSDKStarted = true
     }
-
+    
     override func tearDown() {
         _ = NeuroID.stop()
-
+        
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-
+    
     func assertStoredEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-
+        
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-
+    
     func test_formSubmit() {
         clearOutDataStore()
         let _ = NeuroID.formSubmit()
-
+        
         assertStoredEventTypeAndCount(type: "APPLICATION_SUBMIT", count: 1)
     }
-
+    
     func test_formSubmitFailure() {
         clearOutDataStore()
         let _ = NeuroID.formSubmitFailure()
-
+        
         assertStoredEventTypeAndCount(type: "APPLICATION_SUBMIT_FAILURE", count: 1)
     }
-
+    
     func test_formSubmitSuccess() {
         clearOutDataStore()
         let _ = NeuroID.formSubmitSuccess()
-
+        
         assertStoredEventTypeAndCount(type: "APPLICATION_SUBMIT_SUCCESS", count: 1)
     }
 }
 
 class NIDScreenTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-
+    
     func clearOutDataStore() {
         DataStore.removeSentEvents()
     }
-
+    
     override func setUpWithError() throws {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-
+    
     override func setUp() {
         NeuroID._isSDKStarted = true
     }
-
+    
     override func tearDown() {
         _ = NeuroID.stop()
-
+        
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-
+    
     func assertStoredEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-
+        
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-
+    
     func test_setScreenName_getScreenName() {
         clearOutDataStore()
         let expectedValue = "testScreen"
         let screenNameSet = NeuroID.setScreenName(expectedValue)
-
+        
         let value = NeuroID.getScreenName()
-
+        
         assert(value == expectedValue)
         assert(screenNameSet == true)
-
+        
         assertStoredEventTypeAndCount(type: "MOBILE_METADATA_IOS", count: 1)
     }
-
+    
     func test_setScreenName_getScreenName_withSpace() {
         clearOutDataStore()
         let expectedValue = "test Screen"
         let screenNameSet = NeuroID.setScreenName(expectedValue)
-
+        
         let value = NeuroID.getScreenName()
-
+        
         assert(value == "test%20Screen")
         assert(screenNameSet == true)
-
+        
         assertStoredEventTypeAndCount(type: "MOBILE_METADATA_IOS", count: 1)
     }
-
+    
     func test_setScreenName_not_started() {
         clearOutDataStore()
         NeuroID._isSDKStarted = false
         NeuroID.currentScreenName = ""
         let expectedValue = "test Screen"
         let screenNameSet = NeuroID.setScreenName(expectedValue)
-
+        
         let value = NeuroID.getScreenName()
-
+        
         assert(value != "test%20Screen")
         assert(screenNameSet == false)
-
+        
         let allEvents = DataStore.getAllEvents()
         assert(allEvents.count == 0)
     }
@@ -754,58 +753,58 @@ class NIDScreenTests: XCTestCase {
 
 class NIDUserTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-
+    
     let userIdKey = Constants.storageUserIDKey.rawValue
-
+    
     func clearOutDataStore() {
         DataStore.removeSentEvents()
         let _ = DataStore.getAndRemoveAllQueuedEvents()
     }
-
+    
     override func setUpWithError() throws {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-
+    
     override func setUp() {
         NeuroID._isSDKStarted = true
     }
-
+    
     override func tearDown() {
         _ = NeuroID.stop()
-
+        
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-
+    
     func assertStoredEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-
+        
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-
+    
     func assertQueuedEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.queuedEvents
         let validEvent = allEvents.filter { $0.type == type }
-
+        
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-
+    
     func test_validatedUserID_valid_id() {
         let validUserIds = [
             "123",
             "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
             "a-A_1.0",
         ]
-
+        
         for userId in validUserIds {
             let userNameSet = NeuroID.validateUserID(userId)
             assert(userNameSet == true)
         }
     }
-
+    
     func test_validatedUserID_invalid_id() {
         let invalidUserIds = [
             "",
@@ -816,235 +815,216 @@ class NIDUserTests: XCTestCase {
             "invalid characters",
             "invalid*ch@racters",
         ]
-
+        
         for userId in invalidUserIds {
             let userNameSet = NeuroID.validateUserID(userId)
             assert(userNameSet == false)
         }
     }
-
+    
     func test_setGenericUserID_valid_id_started() {
         NeuroID._isSDKStarted = true
-
+        
         let expectedValue = "myTestUserID"
-        let result = NeuroID.setGenericUserID(
-            userId: expectedValue,
-            type: .userID
-        ) { res in
-            res
-        }
-
+        let result = NeuroID.setGenericUserID(type: .userID, genericUserID: expectedValue, userGenerated: true)
+        
         assert(result == true)
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assert(DataStore.queuedEvents.count == 0)
     }
-
+    
     func test_setGenericUserID_valid_id_queued() {
         NeuroID._isSDKStarted = false
         clearOutDataStore()
-
+        
         let expectedValue = "myTestUserID"
-        let result = NeuroID.setGenericUserID(
-            userId: expectedValue,
-            type: .userID
-        ) { res in
-            res
-        }
-
+        let result = NeuroID.setGenericUserID(type: .userID, genericUserID: expectedValue, userGenerated: true)
+        
         assert(result == true)
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
     }
-
+    
     func test_setGenericUserID_valid_registered_id_started() {
         NeuroID._isSDKStarted = true
-
+        
         let expectedValue = "myTestUserID"
-        let result = NeuroID.setGenericUserID(
-            userId: expectedValue,
-            type: .registeredUserID
-        ) { res in
-            res
-        }
-
+        let result = NeuroID.setGenericUserID(type: .registeredUserID, genericUserID: expectedValue, userGenerated: true)
+        
         assert(result == true)
         assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
         assert(DataStore.queuedEvents.count == 0)
     }
-
+    
     func test_setGenericUserID_valid_registered_id_queued() {
         NeuroID._isSDKStarted = false
         clearOutDataStore()
-
+        
         let expectedValue = "myTestUserID"
-        let result = NeuroID.setGenericUserID(
-            userId: expectedValue,
-            type: .registeredUserID
-        ) { res in
-            res
-        }
-
+        let result = NeuroID.setGenericUserID(type: .registeredUserID, genericUserID: expectedValue, userGenerated: true)
+        
         assert(result == true)
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
     }
-
+    
     func test_setUserID_started() {
         UserDefaults.standard.removeObject(forKey: userIdKey)
-
+        
         let expectedValue = "test_uid"
-        // Reset origin
-        NeuroID.CURRENT_ORIGIN = nil
+        
         let fnSuccess = NeuroID.setUserID(expectedValue)
-
+        
         let storedValue = UserDefaults.standard.string(forKey: userIdKey)
-
+        
         assert(fnSuccess)
         assert(NeuroID.userID == expectedValue)
         assert(storedValue == nil)
-
+        
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assert(NeuroID.CURRENT_ORIGIN == SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        //        assert(NeuroID.CURRENT_ORIGIN == SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue)
         assert(DataStore.queuedEvents.count == 0)
     }
-
+    
     func test_setUserID_pre_start() {
         _ = NeuroID.stop()
         UserDefaults.standard.removeObject(forKey: userIdKey)
-
+        
         let expectedValue = "test_uid"
-
+        
         let fnSuccess = NeuroID.setUserID(expectedValue)
-
+        
         let storedValue = UserDefaults.standard.string(forKey: userIdKey)
-
+        
         assert(fnSuccess == true)
         assert(NeuroID.userID == expectedValue)
         assert(storedValue == nil)
-
+        
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
+        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
     }
-
+    
     func test_getUserID_objectLevel() {
         UserDefaults.standard.removeObject(forKey: userIdKey)
-
+        
         let expectedValue = "test_uid"
-
+        
         NeuroID.userID = expectedValue
-
+        
         let value = NeuroID.getUserID()
-
+        
         assert(NeuroID.userID == expectedValue)
         assert(value == expectedValue)
     }
-
+    
     func test_getUserID_dataStore() {
         let expectedValue = "test_uid"
         UserDefaults.standard.set(expectedValue, forKey: userIdKey)
-
+        
         NeuroID.userID = nil
-
+        
         let value = NeuroID.getUserID()
-
+        
         assert(value == "")
         assert(NeuroID.userID != expectedValue)
     }
-
+    
     func test_getRegisteredUserID_objectLevel() {
         UserDefaults.standard.removeObject(forKey: userIdKey)
-
+        
         let expectedValue = "test_uid"
-
+        
         NeuroID.registeredUserID = expectedValue
-
+        
         let value = NeuroID.getRegisteredUserID()
-
+        
         assert(NeuroID.registeredUserID == expectedValue)
         assert(value == expectedValue)
-
+        
         NeuroID.registeredUserID = ""
     }
-
+    
     func test_setRegisteredUserID_started() {
         UserDefaults.standard.removeObject(forKey: userIdKey)
-
+        
         let expectedValue = "test_ruid"
-
+        
         let fnSuccess = NeuroID.setRegisteredUserID(expectedValue)
-
+        
         let storedValue = UserDefaults.standard.string(forKey: userIdKey)
-
+        
         assert(fnSuccess == true)
         assert(NeuroID.registeredUserID == expectedValue)
         assert(storedValue == nil)
-
+        
         assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
         assert(DataStore.queuedEvents.count == 0)
-
+        
         NeuroID.registeredUserID = ""
     }
-
+    
     func test_setRegisteredUserID_pre_start() {
         _ = NeuroID.stop()
         UserDefaults.standard.removeObject(forKey: userIdKey)
-
+        
         let expectedValue = "test_ruid"
-
+        
         let fnSuccess = NeuroID.setRegisteredUserID(expectedValue)
-
+        
         let storedValue = UserDefaults.standard.string(forKey: userIdKey)
-
+        
         assert(fnSuccess == true)
         assert(NeuroID.registeredUserID == expectedValue)
         assert(storedValue == nil)
-
+        
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
-
+        
         NeuroID.registeredUserID = ""
     }
-
+    
     func test_setRegisteredUserID_already_set() {
         clearOutDataStore()
         NeuroID._isSDKStarted = true
         NeuroID.registeredUserID = "setID"
-
+        
         let expectedValue = "test_ruid"
-
+        
         let fnSuccess = NeuroID.setRegisteredUserID(expectedValue)
-
+        
         assert(fnSuccess == false)
         assert(NeuroID.registeredUserID != expectedValue)
-
+        
         assertStoredEventTypeAndCount(type: "LOG", count: 1)
         assert(DataStore.queuedEvents.count == 0)
-
+        
         NeuroID.registeredUserID = ""
     }
-
+    
     func test_setRegisteredUserID_same_value() {
         clearOutDataStore()
-
+        
         let expectedValue = "test_ruid"
-
+        
         NeuroID.registeredUserID = expectedValue
-
+        
         UserDefaults.standard.removeObject(forKey: userIdKey)
-
+        
         let fnSuccess = NeuroID.setRegisteredUserID(expectedValue)
-
+        
         let storedValue = UserDefaults.standard.string(forKey: userIdKey)
-
+        
         assert(fnSuccess == true)
         assert(NeuroID.registeredUserID == expectedValue)
         assert(storedValue == nil)
-
+        
         assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
-
+        
         NeuroID.registeredUserID = ""
     }
-
+    
     func test_attemptedLoginWthUID() {
         let validID = NeuroID.attemptedLogin("valid_user_id")
         assertStoredEventTypeAndCount(type: "ATTEMPTED_LOGIN", count: 1)
@@ -1055,7 +1035,7 @@ class NIDUserTests: XCTestCase {
         // Value shoould be hashed/salted/prefixed
         XCTAssertEqual("valid_user_id", event[0].uid!)
     }
-
+    
     func test_attemptedLoginWithInvalidID() {
         let invalidID = NeuroID.attemptedLogin("🤣")
         let allEvents = DataStore.getAllEvents()
@@ -1064,7 +1044,7 @@ class NIDUserTests: XCTestCase {
         XCTAssertTrue(invalidID)
         XCTAssertEqual(event[0].uid, "scrubbed-id-failed-validation")
     }
-
+    
     func test_attemptedLoginWithNoUID() {
         _ = NeuroID.attemptedLogin()
         assertStoredEventTypeAndCount(type: "ATTEMPTED_LOGIN", count: 1)
@@ -1072,7 +1052,7 @@ class NIDUserTests: XCTestCase {
         let event = allEvents.filter { $0.type == "ATTEMPTED_LOGIN" }
         XCTAssertEqual(event.last!.uid, "scrubbed-id-failed-validation")
     }
-
+    
     func test_multipleAttemptedLogins() {
         _ = NeuroID.attemptedLogin()
         _ = NeuroID.attemptedLogin()
@@ -1085,19 +1065,19 @@ class NIDEnvTests: XCTestCase {
         NeuroID.environment = Constants.environmentTest.rawValue
         assert(NeuroID.getEnvironment() == "TEST")
     }
-
+    
     func test_setEnvironmentProduction_true() {
         NeuroID.environment = ""
         NeuroID.setEnvironmentProduction(true)
-
+        
         // Should do nothing because deprecated
         assert(NeuroID.getEnvironment() == "")
     }
-
+    
     func test_setEnvironmentProduction_false() {
         NeuroID.environment = ""
         NeuroID.setEnvironmentProduction(false)
-
+        
         // Should do nothing because deprecated
         assert(NeuroID.getEnvironment() == "")
     }
@@ -1105,168 +1085,168 @@ class NIDEnvTests: XCTestCase {
 
 class NIDClientSiteIdTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-
+    
     // Keys for storage:
     let clientKeyKey = Constants.storageClientKey.rawValue
     let cidKey = Constants.storageClientIDKey.rawValue
-
+    
     func test_getClientID() {
         UserDefaults.standard.setValue("test-cid", forKey: cidKey)
         NeuroID.clientID = nil
         let value = NeuroID.getClientID()
-
+        
         assert(value == "test-cid")
     }
-
+    
     func test_getClientId_existing() {
         let expectedValue = "test-cid"
-
+        
         NeuroID.clientID = expectedValue
         UserDefaults.standard.set(expectedValue, forKey: cidKey)
-
+        
         let value = NeuroID.getClientID()
-
+        
         assert(value == expectedValue)
     }
-
+    
     func test_getClientId_random() {
         let expectedValue = "test_cid"
-
+        
         UserDefaults.standard.set(expectedValue, forKey: cidKey)
-
+        
         let value = NeuroID.getClientID()
-
+        
         assert(value != expectedValue)
     }
-
+    
     func test_getClientKey() {
         NeuroID.clientKey = nil
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
         let expectedValue = clientKey
-
+        
         let value = NeuroID.getClientKey()
-
+        
         assert(value == expectedValue)
     }
-
+    
     func test_getClientKeyFromLocalStorage() {
         let expectedValue = "testClientKey"
-
+        
         UserDefaults.standard.setValue(expectedValue, forKey: clientKeyKey)
-
+        
         let value = NeuroID.getClientKeyFromLocalStorage()
         assert(value == expectedValue)
     }
-
+    
     func test_setSiteId() {
         NeuroID.setSiteId(siteId: "test_site")
-
+        
         assert(NeuroID.siteID == "test_site")
     }
-
+    
     func test_validateClientKey_valid_live() {
         let value = NeuroID.validateClientKey("key_live_XXXXXXXXXXX")
-
+        
         assert(value)
     }
-
+    
     func test_validateClientKey_valid_test() {
         let value = NeuroID.validateClientKey("key_test_XXXXXXXXXXX")
-
+        
         assert(value)
     }
-
+    
     func test_validateClientKey_invalid_env() {
         let value = NeuroID.validateClientKey("key_foo_XXXXXXXXXXX")
-
+        
         assert(!value)
     }
-
+    
     func test_validateClientKey_invalid_random() {
         let value = NeuroID.validateClientKey("sdfsdfsdfsdf")
-
+        
         assert(!value)
     }
-
+    
     func test_validateSiteID_valid() {
         let value = NeuroID.validateSiteID("form_peaks345")
-
+        
         assert(value)
     }
-
+    
     func test_validateSiteID_invalid_bad() {
         let value = NeuroID.validateSiteID("badSiteID")
-
+        
         assert(!value)
     }
-
+    
     func test_validateSiteID_invalid_short() {
         let value = NeuroID.validateSiteID("form_abc123")
-
+        
         assert(!value)
     }
 }
 
 class NIDSendTests: XCTestCase {
     func test_getCollectionEndpointURL() {
-        let expectedValue = "https://receiver.neuro-dev.com/c"
-
+        let expectedValue = "https://receiver.neuroid.cloud/c"
+        
         let value = NeuroID.getCollectionEndpointURL()
         assert(value == expectedValue)
     }
-
+    
     func test_initCollectionTimer_item() {
         NeuroID._isSDKStarted = false
         let expectation = XCTestExpectation(description: "Wait for 5 seconds")
-
+        
         let workItem = DispatchWorkItem {
             NeuroID._isSDKStarted = true
             expectation.fulfill()
         }
         NeuroID.sendCollectionWorkItem = workItem
-
+        
         NeuroID.initCollectionTimer()
-
+        
         // Wait for the expectation to be fulfilled, or timeout after 7 seconds
         wait(for: [expectation], timeout: 7)
-
+        
         assert(NeuroID._isSDKStarted)
         NeuroID._isSDKStarted = false
     }
-
+    
     func test_initCollectionTimer_item_nil() {
         NeuroID._isSDKStarted = false
         let expectation = XCTestExpectation(description: "Wait for 5 seconds")
-
+        
         // setting the item as nil so the queue won't run
         NeuroID.sendCollectionWorkItem = nil
-
+        
         DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
             expectation.fulfill()
         }
-
+        
         NeuroID.initCollectionTimer()
-
+        
         // Wait for the expectation to be fulfilled, or timeout after 7 seconds
         wait(for: [expectation], timeout: 7)
-
+        
         assert(!NeuroID._isSDKStarted)
         NeuroID._isSDKStarted = false
     }
-
-//    createCollectionWorkItem // Not sure how to test because it returns an item that always exists
+    
+    //    createCollectionWorkItem // Not sure how to test because it returns an item that always exists
 }
 
 class NIDLogTests: XCTestCase {
     func test_enableLogging_true() {
         NeuroID.enableLogging(true)
-
+        
         assert(NeuroID.showLogs)
     }
-
+    
     func test_enableLogging_false() {
         NeuroID.enableLogging(false)
-
+        
         assert(!NeuroID.showLogs)
     }
 }
@@ -1276,76 +1256,76 @@ class NIDRNTests: XCTestCase {
         NeuroID.isRN = false
         NeuroID.clientKey = nil
     }
-
+    
     let configOptionsTrue = [RNConfigOptions.usingReactNavigation.rawValue: true, RNConfigOptions.isAdvancedDevice.rawValue: false]
     let configOptionsFalse = [RNConfigOptions.usingReactNavigation.rawValue: false]
     let configOptionsInvalid = ["foo": "bar"]
-
+    
     func assertConfigureTests(defaultValue: Bool, expectedValue: Bool) {
         assert(NeuroID.isRN)
         let storedValue = NeuroID.rnOptions[.usingReactNavigation] as? Bool ?? defaultValue
         assert(storedValue == expectedValue)
         assert(NeuroID.rnOptions.count == 1)
     }
-
+    
     func test_isRN() {
         assert(!NeuroID.isRN)
         NeuroID.setIsRN()
-
+        
         assert(NeuroID.isRN)
     }
-
+    
     func test_configure_usingReactNavigation_true() {
         assert(!NeuroID.isRN)
         let configured = NeuroID.configure(
             clientKey: "key_test_XXXXXXXXXXX",
             rnOptions: configOptionsTrue
         )
-
+        
         assert(configured)
         assertConfigureTests(defaultValue: false, expectedValue: true)
     }
-
+    
     func test_configure_usingReactNavigation_false() {
         assert(!NeuroID.isRN)
         let configured = NeuroID.configure(
             clientKey: "key_test_XXXXXXXXXXX",
             rnOptions: configOptionsFalse
         )
-
+        
         assert(configured)
         assertConfigureTests(defaultValue: true, expectedValue: false)
     }
-
+    
     func test_configure_invalid_key() {
         assert(!NeuroID.isRN)
         let configured = NeuroID.configure(
             clientKey: "key_test_XXXXXXXXXXX",
             rnOptions: configOptionsInvalid
         )
-
+        
         assert(configured)
         assertConfigureTests(defaultValue: true, expectedValue: false)
     }
-
+    
     func test_getOptionValueBool_true() {
         assert(!NeuroID.isRN)
         let value = NeuroID.getOptionValueBool(rnOptions: configOptionsTrue, configOptionKey: .usingReactNavigation)
-
+        
         assert(value)
     }
-
+    
     func test_getOptionValueBool_false() {
         assert(!NeuroID.isRN)
         let value = NeuroID.getOptionValueBool(rnOptions: configOptionsFalse, configOptionKey: .usingReactNavigation)
-
+        
         assert(!value)
     }
-
+    
     func test_getOptionValueBool_invalid() {
         assert(!NeuroID.isRN)
         let value = NeuroID.getOptionValueBool(rnOptions: configOptionsInvalid, configOptionKey: .usingReactNavigation)
-
+        
         assert(!value)
     }
 }

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -529,6 +529,10 @@ class NIDNewSessionTests: XCTestCase {
             self.assertSessionStartedTests(sessionRes)
             assert(expectedValue == sessionRes.sessionID)
         }
+        // TODO-How are events showing up in Datastore and not Queue
+        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertStoredEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue)
     }
     
     func test_startSession_success_no_id() {
@@ -540,10 +544,10 @@ class NIDNewSessionTests: XCTestCase {
             self.assertSessionStartedTests(sessionRes)
             assert(expectedValue != sessionRes.sessionID)
         }
-        //        TODO-Queue events not showing
-        //        assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        //        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
-        //        assertQueuedEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue)
+        // TODO-How are events showing up in Datastore and not Queue
+        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertStoredEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue)
     }
     
     func test_startSession_success_no_id_sdk_started() {
@@ -940,7 +944,7 @@ class NIDUserTests: XCTestCase {
         assert(result == true)
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
     }
     
     func test_setGenericUserID_valid_registered_id_started() {
@@ -965,7 +969,7 @@ class NIDUserTests: XCTestCase {
         assert(result == true)
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
     }
     
     func test_setGenericUserID_invalid_id_started() {

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -11,89 +11,89 @@ import XCTest
 
 class NeuroIDClassTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-    
+
     // Keys for storage:
     let localStorageNIDStopAll = Constants.storageLocalNIDStopAllKey.rawValue
     let clientKeyKey = Constants.storageClientKey.rawValue
     let tabIdKey = Constants.storageTabIDKey.rawValue
-    
+
     let mockService = MockDeviceSignalService()
-    
+
     func clearOutDataStore() {
         let _ = DataStore.getAndRemoveAllEvents()
     }
-    
+
     override func setUpWithError() throws {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-    
+
     override func setUp() {
         UserDefaults.standard.removeObject(forKey: Constants.storageAdvancedDeviceKey.rawValue)
-        mockService.mockResult = .success(("mock", Double(Int.random(in: 0..<3000))))
+        mockService.mockResult = .success(("mock", Double(Int.random(in: 0 ..< 3000))))
     }
-    
+
     override func tearDown() {
         _ = NeuroID.stop()
-        
+
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-    
+
     func test_getAdvDeviceLatency() {
         let mockService = MockDeviceSignalService()
         NeuroID.deviceSignalService = mockService
         _ = NeuroID.configure(clientKey: "key_test_0OMmplsawAp2CQfWrytWA3wL")
-        let randomTimeInMilliseconds = Double(Int.random(in: 0..<3000))
+        let randomTimeInMilliseconds = Double(Int.random(in: 0 ..< 3000))
         mockService.mockResult = .success(("empty mock result. Can be filled with anything", randomTimeInMilliseconds))
         NeuroID.start(true) { _ in
             let allEvents = DataStore.getAllEvents()
-            
+
             let validEvent = allEvents.filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
             XCTAssertTrue(validEvent.count == 1)
         }
     }
-    
+
     func assertDataStoreCount(count: Int) {
         let allEvents = DataStore.getAllEvents()
         assert(allEvents.count == count)
     }
-    
+
     func assertStoredEventCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-        
+
         assert(validEvent.count == count)
     }
-    
+
     func assertStoredEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-        
+
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-    
+
     func test_configure_success() {
         clearOutDataStore()
         // remove things configured in setup
         NeuroID.clientKey = nil
         UserDefaults.standard.setValue(nil, forKey: clientKeyKey)
         UserDefaults.standard.setValue("testTabId", forKey: tabIdKey)
-        
+
         let configured = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
         assert(configured)
-        
+
         let clientKeyValue = UserDefaults.standard.string(forKey: clientKeyKey)
         assert(clientKeyValue == clientKey)
-        
+
         let tabIdValue = UserDefaults.standard.string(forKey: tabIdKey)
         assert(tabIdValue == nil)
-        
+
         assertStoredEventCount(type: "CREATE_SESSION", count: 0)
-        
+
         assert(NeuroID.environment == "\(Constants.environmentLive.rawValue)")
     }
-    
+
     func test_configure_invalidKey() {
         clearOutDataStore()
         // remove things configured in setup
@@ -101,30 +101,30 @@ class NeuroIDClassTests: XCTestCase {
         NeuroID.clientKey = nil
         UserDefaults.standard.setValue(nil, forKey: clientKeyKey)
         UserDefaults.standard.setValue("testTabId", forKey: tabIdKey)
-        
+
         let configured = NeuroID.configure(clientKey: "invalid_key", isAdvancedDevice: false)
         assert(configured == false)
-        
+
         let clientKeyValue = UserDefaults.standard.string(forKey: clientKeyKey)
         assert(clientKeyValue == nil)
-        
+
         let tabIdValue = UserDefaults.standard.string(forKey: tabIdKey)
         assert(tabIdValue == "testTabId")
-        
+
         assertStoredEventCount(type: "CREATE_SESSION", count: 0)
-        
+
         assert(NeuroID.environment == "\(Constants.environmentTest.rawValue)")
     }
-    
+
     func test_start_failure() {
         tearDown()
         NeuroID._isSDKStarted = false
         NeuroID.clientKey = nil
-        
+
         // pre tests
         assert(!NeuroID.isSDKStarted)
         assert(NeuroID.clientKey == nil)
-        
+
         // action
         NeuroID.start { started in
             assert(!started)
@@ -132,14 +132,14 @@ class NeuroIDClassTests: XCTestCase {
             assert(!NeuroID.isSDKStarted)
         }
     }
-    
+
     func test_start_success() {
         tearDown()
         NeuroID._isSDKStarted = false
-        
+
         // pre tests
         assert(!NeuroID.isSDKStarted)
-        
+
         // action
         NeuroID.start { started in
             // post action test
@@ -150,25 +150,25 @@ class NeuroIDClassTests: XCTestCase {
             self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 1)
         }
     }
-    
+
     func test_start_success_queuedEvent() {
         _ = NeuroID.stop()
         let setUserIDRes = NeuroID.setUserID("test_uid")
-        
+
         assert(setUserIDRes)
-        
+
         NeuroID._isSDKStarted = false
-        
+
         // pre tests
         assert(!NeuroID.isSDKStarted)
-        
+
         // action
         NeuroID.start { started in
-            
+
             // post action test
             assert(started)
             assert(NeuroID.isSDKStarted)
-            
+
             assert(DataStore.events.count == 7)
             self.assertStoredEventCount(type: "CREATE_SESSION", count: 1)
             self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 1)
@@ -176,128 +176,128 @@ class NeuroIDClassTests: XCTestCase {
             self.assertStoredEventCount(type: "SET_VARIABLE", count: 4)
         }
     }
-    
+
     func test_stop() {
         NeuroID._isSDKStarted = true
         assert(NeuroID.isSDKStarted)
-        
+
         let stopped = NeuroID.stop()
         assert(stopped)
         assert(!NeuroID.isSDKStarted)
     }
-    
+
     func test_getSDKVersion() {
         let expectedValue = ParamsCreator.getSDKVersion()
-        
+
         let value = NeuroID.getSDKVersion()
-        
+
         assert(value == expectedValue)
     }
 }
 
 class NIDRegistrationTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-    
+
     func clearOutDataStore() {
         DataStore.removeSentEvents()
     }
-    
+
     override func setUpWithError() throws {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-    
+
     override func setUp() {
         NeuroID._isSDKStarted = true
     }
-    
+
     override func tearDown() {
         _ = NeuroID.stop()
-        
+
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-    
+
     func assertDataStoreCount(count: Int) {
         let allEvents = DataStore.getAllEvents()
         assert(allEvents.count == count)
     }
-    
+
     func assertStoredEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-        
+
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-    
+
     func test_excludeViewByTestID() {
         clearOutDataStore()
         NeuroID.excludedViewsTestIDs = []
         let expectedValue = "testScreenName"
-        
+
         NeuroID.excludeViewByTestID(excludedView: expectedValue)
-        
+
         let contains = NeuroID.excludedViewsTestIDs.contains(where: { $0 == expectedValue })
         assert(contains)
-        
+
         assert(NeuroID.excludedViewsTestIDs.count == 1)
     }
-    
+
     func test_manuallyRegisterTarget_valid_type() {
         clearOutDataStore()
         let uiView = UITextField()
         uiView.id = "wow"
-        
+
         NeuroID.manuallyRegisterTarget(view: uiView)
-        
+
         assertStoredEventTypeAndCount(type: "REGISTER_TARGET", count: 1)
-        
+
         let allEvents = DataStore.getAllEvents()
         let validEvents = allEvents.filter { $0.type == "REGISTER_TARGET" }
         assert(validEvents[0].tgs == "wow")
         assert(validEvents[0].et == "UITextField::UITextField")
     }
-    
+
     func test_manuallyRegisterTarget_invalid_type() {
         clearOutDataStore()
         let uiView = UIView()
-        
+
         NeuroID.manuallyRegisterTarget(view: uiView)
-        
+
         assertDataStoreCount(count: 0)
     }
-    
+
     func test_manuallyRegisterRNTarget() {
         clearOutDataStore()
-        
+
         let event = NeuroID.manuallyRegisterRNTarget(
             id: "test",
             className: "testClassName",
             screenName: "testScreenName",
             placeHolder: "testPlaceholder"
         )
-        
+
         assert(event.tgs == "test")
         assert(event.et == "testClassName")
         assert(event.etn == "INPUT")
-        
+
         assertStoredEventTypeAndCount(type: "REGISTER_TARGET", count: 1)
     }
-    
+
     func test_setCustomVariable() {
         clearOutDataStore()
         let event = NeuroID.setCustomVariable(key: "t", v: "v")
-        
+
         XCTAssertTrue(event.type == NIDSessionEventName.setVariable.rawValue)
         XCTAssertTrue(event.key == "t")
         XCTAssertTrue(event.v == "v")
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 1)
     }
-    
+
     func test_setVariable() {
         clearOutDataStore()
         let event = NeuroID.setVariable(key: "t", value: "v")
-        
+
         XCTAssertTrue(event.type == NIDSessionEventName.setVariable.rawValue)
         XCTAssertTrue(event.key == "t")
         XCTAssertTrue(event.v == "v")
@@ -307,88 +307,88 @@ class NIDRegistrationTests: XCTestCase {
 
 class NIDSessionTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-    
+
     let sessionIdKey = Constants.storageSessionIDKey.rawValue
     let clientIdKey = Constants.storageClientIDKey.rawValue
-    
+
     func clearOutDataStore() {
         DataStore.removeSentEvents()
     }
-    
+
     override func setUpWithError() throws {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-    
+
     override func setUp() {
         NeuroID._isSDKStarted = true
     }
-    
+
     override func tearDown() {
         _ = NeuroID.stop()
-        
+
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-    
+
     func assertStoredEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-        
+
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-    
+
     func test_clearStoredSessionID() {
         UserDefaults.standard.set("session", forKey: sessionIdKey)
         UserDefaults.standard.set("client", forKey: clientIdKey)
-        
+
         NeuroID.clearStoredSessionID()
-        
+
         let session = UserDefaults.standard.string(forKey: sessionIdKey)
         let client = UserDefaults.standard.string(forKey: clientIdKey)
-        
+
         assert(session == nil)
         assert(client != nil)
     }
-    
+
     func test_getSessionID() {
         let expectedValue = "session"
         UserDefaults.standard.set(expectedValue, forKey: sessionIdKey)
-        
+
         let value = NeuroID.getSessionID()
-        
+
         assert(value == expectedValue)
     }
-    
+
     func test_getSessionID_existing() {
         let expectedValue = "test_sid"
         UserDefaults.standard.set(expectedValue, forKey: sessionIdKey)
-        
+
         let value = NeuroID.getSessionID()
-        
+
         assert(value == expectedValue)
     }
-    
+
     func test_getSessionID_random() {
         UserDefaults.standard.set(nil, forKey: sessionIdKey)
-        
+
         let value = NeuroID.getSessionID()
-        
+
         assert(value != "")
         assert(value.count == 40)
         assert(value.hasPrefix("nid-"))
     }
-    
+
     func test_createSession() {
         clearOutDataStore()
         DataStore.removeSentEvents()
-        
+
         NeuroID.createSession()
-        
+
         assertStoredEventTypeAndCount(type: "CREATE_SESSION", count: 1)
         assertStoredEventTypeAndCount(type: "MOBILE_METADATA_IOS", count: 1)
     }
-    
+
     func test_closeSession() {
         clearOutDataStore()
         do {
@@ -398,149 +398,149 @@ class NIDSessionTests: XCTestCase {
             NIDLog.e("Threw on Close Session that shouldn't")
             XCTFail()
         }
-        
+
         //        assertStoredEventTypeAndCount(type: "CLOSE_SESSION", count: 1)
     }
-    
+
     func test_closeSession_whenStopped() {
         _ = NeuroID.stop()
         clearOutDataStore()
-        
+
         XCTAssertThrowsError(
             try NeuroID.closeSession(),
             "Close Session throws an error when SDK is already stopped"
         )
     }
-    
+
     func test_captureMobileMetadata() {
         clearOutDataStore()
-        
+
         NeuroID.captureMobileMetadata()
-        
+
         assertStoredEventTypeAndCount(type: NIDSessionEventName.mobileMetadataIOS.rawValue, count: 1)
     }
 }
 
 class NIDNewSessionTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-    
+
     let sessionIdKey = Constants.storageSessionIDKey.rawValue
     let clientIdKey = Constants.storageClientIDKey.rawValue
-    
+
     func clearOutDataStore() {
         DataStore.removeSentEvents()
         _ = DataStore.getAndRemoveAllQueuedEvents()
     }
-    
+
     override func setUpWithError() throws {
         NeuroID.configService = MockConfigService()
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-    
+
     override func tearDown() {
         _ = NeuroID.stop()
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-    
+
     func assertStoredEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-        
+
         assert(validEvent.count == count)
         if !skipType! {
             assert(validEvent[0].type == type)
         }
     }
-    
+
     func assertQueuedEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
         let allEvents = DataStore.queuedEvents
         let validEvent = allEvents.filter { $0.type == type }
-        
+
         assert(validEvent.count == count)
         if !skipType! {
             assert(validEvent[0].type == type)
         }
     }
-    
+
     func assertDatastoreEventOrigin(type: String, origin: String, originCode: String, queued: Bool) {
         let allEvents = queued ? DataStore.queuedEvents : DataStore.getAllEvents()
         let validEvents = allEvents.filter { $0.type == type }
-        
+
         let originEvent = validEvents.filter { $0.key == "sessionIdSource" }
         assert(originEvent.count == 1)
         assert(originEvent[0].v == origin)
-        
+
         let originCodeEvent = validEvents.filter { $0.key == "sessionIdCode" }
         assert(originCodeEvent.count == 1)
         assert(originCodeEvent[0].v == originCode)
     }
-    
+
     func assertSessionStartedTests(_ sessionRes: SessionStartResult) {
         assert(sessionRes.started)
         assert(NeuroID._isSDKStarted)
         assert(NeuroID.sendCollectionWorkItem == nil) // In real world it would != nil but because of tests we don't want to trigger a re-occuring event
-        
+
         assertStoredEventTypeAndCount(type: NIDSessionEventName.createSession.rawValue, count: 1)
         assertStoredEventTypeAndCount(type: NIDSessionEventName.mobileMetadataIOS.rawValue, count: 1)
         assertStoredEventTypeAndCount(type: NIDSessionEventName.setUserId.rawValue, count: 1)
         assert(DataStore.queuedEvents.isEmpty)
     }
-    
+
     func assertSessionNotStartedTests(_ sessionRes: SessionStartResult) {
         assert(!sessionRes.started)
         assert(sessionRes.sessionID == "")
         assert(!NeuroID._isSDKStarted)
         assert(NeuroID.sendCollectionWorkItem == nil) // In real world it would != nil but because of tests we don't want to trigger a re-occuring event
     }
-    
+
     //    clearSessionVariables
     func test_clearSessionVariables() {
         NeuroID.userID = "myUserID"
         NeuroID.registeredUserID = "myRegisteredUserID"
         NeuroID.linkedSiteID = "mySite"
-        
+
         NeuroID.clearSessionVariables()
-        
+
         assert(NeuroID.userID == nil)
         assert(NeuroID.registeredUserID == "")
         assert(NeuroID.linkedSiteID == nil)
     }
-    
+
     func test_startSession_success_id() {
         NeuroID.userID = nil
         NeuroID._isSDKStarted = false
-        
+
         let expectedValue = "mySessionID"
         NeuroID.startSession(expectedValue) { sessionRes in
             self.assertSessionStartedTests(sessionRes)
             assert(expectedValue == sessionRes.sessionID)
         }
-        
+
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
     }
-    
+
     func test_startSession_success_no_id() {
         NeuroID.userID = nil
         NeuroID._isSDKStarted = false
-        
+
         let expectedValue = "mySessionID"
         NeuroID.startSession { sessionRes in
             self.assertSessionStartedTests(sessionRes)
             assert(expectedValue != sessionRes.sessionID)
         }
-        
+
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
     }
-    
+
     func test_startSession_success_no_id_sdk_started() {
         NeuroID.userID = nil
         NeuroID._isSDKStarted = true
-        
+
         let expectedValue = "mySessionID"
         NeuroID.startSession { sessionRes in
             self.assertSessionStartedTests(sessionRes)
@@ -550,11 +550,11 @@ class NIDNewSessionTests: XCTestCase {
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
     }
-    
+
     func test_startSession_success_id_sdk_started() {
         NeuroID.userID = nil
         NeuroID._isSDKStarted = true
-        
+
         let expectedValue = "mySessionID"
         NeuroID.startSession(expectedValue) { sessionRes in
             self.assertSessionStartedTests(sessionRes)
@@ -564,16 +564,16 @@ class NIDNewSessionTests: XCTestCase {
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
     }
-    
+
     func test_startSession_failure_clientKey() {
         NeuroID.clientKey = nil
         NeuroID.sendCollectionWorkItem = nil
-        
+
         NeuroID.startSession { sessionRes in
             self.assertSessionNotStartedTests(sessionRes)
         }
     }
-    
+
     func test_startSession_failure_userID() {
         NeuroID.sendCollectionWorkItem = nil
         NeuroID.startSession("MY bad -.-. id") {
@@ -584,96 +584,96 @@ class NIDNewSessionTests: XCTestCase {
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: true)
     }
-    
+
     func test_pauseCollection() {
         NeuroID._isSDKStarted = true
         NeuroID.sendCollectionWorkItem = DispatchWorkItem {}
-        
+
         NeuroID.pauseCollection()
-        
+
         assert(!NeuroID._isSDKStarted)
         assert(NeuroID.sendCollectionWorkItem == nil)
     }
-    
+
     func test_resumeCollection() {
         NeuroID._isSDKStarted = false
         NeuroID.userID = "temp"
         NeuroID.sendCollectionWorkItem = nil
-        
+
         NeuroID.resumeCollection()
-        
+
         assert(NeuroID._isSDKStarted)
         assert(NeuroID.sendCollectionWorkItem != nil)
     }
-    
+
     func test_willNotResumeCollectionIfNotStarted() {
         NeuroID._isSDKStarted = false
         NeuroID.userID = nil
         NeuroID.resumeCollection()
-        
+
         assert(!NeuroID._isSDKStarted)
     }
-    
+
     func test_stopSession() {
         let stopped = NeuroID.stopSession()
-        
+
         assert(stopped)
     }
-    
+
     func test_startAppFlow_valid_site() {
         let mySite = "form_thing123"
         NeuroID._isSDKStarted = true
         NeuroID.linkedSiteID = nil
-        
+
         NeuroID.startAppFlow(siteID: mySite) { started in
             assert(started.started)
             assert(NeuroID.linkedSiteID == mySite)
-            
+
             NeuroID._isSDKStarted = false
             NeuroID.linkedSiteID = nil
         }
     }
-    
+
     func test_startAppFlow_invalid_site() {
         let mySite = "mySite"
         NeuroID._isSDKStarted = true
         NeuroID.linkedSiteID = nil
-        
+
         NeuroID.startAppFlow(siteID: mySite) { started in
             assert(!started.started)
             assert(NeuroID.linkedSiteID == nil)
-            
+
             NeuroID._isSDKStarted = false
         }
     }
-    
+
     func test_clearSendOldFlowEvents_not_sampled() {
         DataStore.events.append(NIDEvent(rawType: "test"))
         let mockSampling = NIDSamplingService()
         mockSampling._isSessionFlowSampled = false
         NeuroID.samplingService = mockSampling
-        
+
         NeuroID.clearSendOldFlowEvents {
             assert(DataStore.events.count == 0)
-            
+
             NeuroID._isSDKStarted = false
         }
     }
-    
+
     func test_clearSendOldFlowEvents_sampled() {
         DataStore.events.append(NIDEvent(rawType: "test"))
         let mockSampling = NIDSamplingService()
         mockSampling._isSessionFlowSampled = true
         NeuroID.samplingService = mockSampling
-        
+
         let mockNetwork = NIDNetworkServiceTestImpl()
         NeuroID.networkService = mockNetwork
-        
+
         NeuroID._isSDKStarted = true
-        
+
         NeuroID.clearSendOldFlowEvents {
             assert(DataStore.events.count == 0)
-            
+
             NeuroID._isSDKStarted = false
         }
     }
@@ -681,127 +681,127 @@ class NIDNewSessionTests: XCTestCase {
 
 class NIDFormTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-    
+
     let sessionIdKey = Constants.storageSessionIDKey.rawValue
     let clientIdKey = Constants.storageClientIDKey.rawValue
-    
+
     func clearOutDataStore() {
         DataStore.removeSentEvents()
     }
-    
+
     override func setUpWithError() throws {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-    
+
     override func setUp() {
         NeuroID._isSDKStarted = true
     }
-    
+
     override func tearDown() {
         _ = NeuroID.stop()
-        
+
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-    
+
     func assertStoredEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-        
+
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-    
+
     func test_formSubmit() {
         clearOutDataStore()
         let _ = NeuroID.formSubmit()
-        
+
         assertStoredEventTypeAndCount(type: "APPLICATION_SUBMIT", count: 1)
     }
-    
+
     func test_formSubmitFailure() {
         clearOutDataStore()
         let _ = NeuroID.formSubmitFailure()
-        
+
         assertStoredEventTypeAndCount(type: "APPLICATION_SUBMIT_FAILURE", count: 1)
     }
-    
+
     func test_formSubmitSuccess() {
         clearOutDataStore()
         let _ = NeuroID.formSubmitSuccess()
-        
+
         assertStoredEventTypeAndCount(type: "APPLICATION_SUBMIT_SUCCESS", count: 1)
     }
 }
 
 class NIDScreenTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-    
+
     func clearOutDataStore() {
         DataStore.removeSentEvents()
     }
-    
+
     override func setUpWithError() throws {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-    
+
     override func setUp() {
         NeuroID._isSDKStarted = true
     }
-    
+
     override func tearDown() {
         _ = NeuroID.stop()
-        
+
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-    
+
     func assertStoredEventTypeAndCount(type: String, count: Int) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-        
+
         assert(validEvent.count == count)
         assert(validEvent[0].type == type)
     }
-    
+
     func test_setScreenName_getScreenName() {
         clearOutDataStore()
         let expectedValue = "testScreen"
         let screenNameSet = NeuroID.setScreenName(expectedValue)
-        
+
         let value = NeuroID.getScreenName()
-        
+
         assert(value == expectedValue)
         assert(screenNameSet == true)
-        
+
         assertStoredEventTypeAndCount(type: "MOBILE_METADATA_IOS", count: 1)
     }
-    
+
     func test_setScreenName_getScreenName_withSpace() {
         clearOutDataStore()
         let expectedValue = "test Screen"
         let screenNameSet = NeuroID.setScreenName(expectedValue)
-        
+
         let value = NeuroID.getScreenName()
-        
+
         assert(value == "test%20Screen")
         assert(screenNameSet == true)
-        
+
         assertStoredEventTypeAndCount(type: "MOBILE_METADATA_IOS", count: 1)
     }
-    
+
     func test_setScreenName_not_started() {
         clearOutDataStore()
         NeuroID._isSDKStarted = false
         NeuroID.currentScreenName = ""
         let expectedValue = "test Screen"
         let screenNameSet = NeuroID.setScreenName(expectedValue)
-        
+
         let value = NeuroID.getScreenName()
-        
+
         assert(value != "test%20Screen")
         assert(screenNameSet == false)
-        
+
         let allEvents = DataStore.getAllEvents()
         assert(allEvents.count == 0)
     }
@@ -809,75 +809,75 @@ class NIDScreenTests: XCTestCase {
 
 class NIDUserTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-    
+
     let userIdKey = Constants.storageUserIDKey.rawValue
-    
+
     func clearOutDataStore() {
         DataStore.removeSentEvents()
         let _ = DataStore.getAndRemoveAllQueuedEvents()
     }
-    
+
     override func setUpWithError() throws {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
     }
-    
+
     override func setUp() {
         NeuroID._isSDKStarted = true
     }
-    
+
     override func tearDown() {
         _ = NeuroID.stop()
-        
+
         // Clear out the DataStore Events after each test
         clearOutDataStore()
     }
-    
+
     func assertStoredEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
         let allEvents = DataStore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-        
+
         assert(validEvent.count == count)
         if !skipType! {
             assert(validEvent[0].type == type)
         }
     }
-    
+
     func assertQueuedEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
         let allEvents = DataStore.queuedEvents
         let validEvent = allEvents.filter { $0.type == type }
-        
+
         assert(validEvent.count == count)
         if !skipType! {
             assert(validEvent[0].type == type)
         }
     }
-    
+
     func assertDatastoreEventOrigin(type: String, origin: String, originCode: String, queued: Bool) {
         let allEvents = queued ? DataStore.queuedEvents : DataStore.getAllEvents()
         let validEvents = allEvents.filter { $0.type == type }
-        
+
         let originEvent = validEvents.filter { $0.key == "sessionIdSource" }
         assert(originEvent.count == 1)
         assert(originEvent[0].v == origin)
-        
+
         let originCodeEvent = validEvents.filter { $0.key == "sessionIdCode" }
         assert(originCodeEvent.count == 1)
         assert(originCodeEvent[0].v == originCode)
     }
-    
+
     func test_validatedUserID_valid_id() {
         let validUserIds = [
             "123",
             "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
             "a-A_1.0",
         ]
-        
+
         for userId in validUserIds {
             let userNameSet = NeuroID.validateUserID(userId)
             assert(userNameSet == true)
         }
     }
-    
+
     func test_validatedUserID_invalid_id() {
         let invalidUserIds = [
             "",
@@ -888,291 +888,291 @@ class NIDUserTests: XCTestCase {
             "invalid characters",
             "invalid*ch@racters",
         ]
-        
+
         for userId in invalidUserIds {
             let userNameSet = NeuroID.validateUserID(userId)
             assert(userNameSet == false)
         }
     }
-    
+
     func test_setGenericUserID_valid_id_started() {
         NeuroID._isSDKStarted = true
-        
+
         let expectedValue = "myTestUserID"
         let result = NeuroID.setGenericUserID(type: .userID, genericUserID: expectedValue, userGenerated: true)
-        
+
         assert(result == true)
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assert(DataStore.queuedEvents.count == 0)
     }
-    
+
     func test_setGenericUserID_valid_id_queued() {
         NeuroID._isSDKStarted = false
         clearOutDataStore()
-        
+
         let expectedValue = "myTestUserID"
         let result = NeuroID.setGenericUserID(type: .userID, genericUserID: expectedValue, userGenerated: true)
-        
+
         assert(result == true)
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
     }
-    
+
     func test_setGenericUserID_valid_registered_id_started() {
         NeuroID._isSDKStarted = true
-        
+
         let expectedValue = "myTestUserID"
         let result = NeuroID.setGenericUserID(type: .registeredUserID, genericUserID: expectedValue, userGenerated: true)
-        
+
         assert(result == true)
         assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assert(DataStore.queuedEvents.count == 0)
     }
-    
+
     func test_setGenericUserID_valid_registered_id_queued() {
         NeuroID._isSDKStarted = false
         clearOutDataStore()
-        
+
         let expectedValue = "myTestUserID"
         let result = NeuroID.setGenericUserID(type: .registeredUserID, genericUserID: expectedValue, userGenerated: true)
-        
+
         assert(result == true)
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
     }
-    
+
     func test_setGenericUserID_invalid_id_started() {
         NeuroID._isSDKStarted = true
         clearOutDataStore()
         let expectedValue = "$!&*"
         let result = NeuroID.setGenericUserID(type: .userID, genericUserID: expectedValue, userGenerated: true)
-        
+
         assert(result == false)
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: false)
     }
-    
+
     func test_setGenericUserID_invalid_id_queued() {
         NeuroID._isSDKStarted = false
         clearOutDataStore()
-        
+
         let expectedValue = "$!&*"
         let result = NeuroID.setGenericUserID(type: .userID, genericUserID: expectedValue, userGenerated: true)
-        
+
         assert(result == false)
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: true)
     }
-    
+
     func test_setUserID_started_customer_origin() {
         UserDefaults.standard.removeObject(forKey: userIdKey)
-        
+
         let expectedValue = "test_uid"
-        
+
         let fnSuccess = NeuroID.setUserID(expectedValue)
-        
+
         let storedValue = UserDefaults.standard.string(forKey: userIdKey)
-        
+
         assert(fnSuccess)
         assert(NeuroID.userID == expectedValue)
         assert(storedValue == nil)
-        
+
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
-        
+
         assert(DataStore.queuedEvents.count == 0)
     }
-    
+
     func test_setUserID_pre_start_customer_origin() {
         _ = NeuroID.stop()
         UserDefaults.standard.removeObject(forKey: userIdKey)
-        
+
         let expectedValue = "test_uid"
-        
+
         let fnSuccess = NeuroID.setUserID(expectedValue)
-        
+
         let storedValue = UserDefaults.standard.string(forKey: userIdKey)
-        
+
         assert(fnSuccess == true)
         assert(NeuroID.userID == expectedValue)
         assert(storedValue == nil)
-        
+
         //        assert(DataStore.events.count == 0) "NETWORK_STATE" event present
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: true)
     }
-    
+
     func test_setUserID_started_nid_origin() {
         UserDefaults.standard.removeObject(forKey: userIdKey)
-        
+
         let expectedValue = "test_uid"
-        
+
         let fnSuccess = NeuroID.setUserID(expectedValue, false)
-        
+
         let storedValue = UserDefaults.standard.string(forKey: userIdKey)
-        
+
         assert(fnSuccess)
         assert(NeuroID.userID == expectedValue)
         assert(storedValue == nil)
-        
+
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
-        
+
         assert(DataStore.queuedEvents.count == 0)
     }
-    
+
     func test_setUserID_pre_start_nid_origin() {
         _ = NeuroID.stop()
         UserDefaults.standard.removeObject(forKey: userIdKey)
-        
+
         let expectedValue = "test_uid"
-        
+
         let fnSuccess = NeuroID.setUserID(expectedValue, false)
-        
+
         let storedValue = UserDefaults.standard.string(forKey: userIdKey)
-        
+
         assert(fnSuccess == true)
         assert(NeuroID.userID == expectedValue)
         assert(storedValue == nil)
-        
+
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: true)
     }
-    
+
     func test_getUserID_objectLevel() {
         UserDefaults.standard.removeObject(forKey: userIdKey)
-        
+
         let expectedValue = "test_uid"
-        
+
         NeuroID.userID = expectedValue
-        
+
         let value = NeuroID.getUserID()
-        
+
         assert(NeuroID.userID == expectedValue)
         assert(value == expectedValue)
     }
-    
+
     func test_getUserID_dataStore() {
         let expectedValue = "test_uid"
         UserDefaults.standard.set(expectedValue, forKey: userIdKey)
-        
+
         NeuroID.userID = nil
-        
+
         let value = NeuroID.getUserID()
-        
+
         assert(value == "")
         assert(NeuroID.userID != expectedValue)
     }
-    
+
     func test_getRegisteredUserID_objectLevel() {
         UserDefaults.standard.removeObject(forKey: userIdKey)
-        
+
         let expectedValue = "test_uid"
-        
+
         NeuroID.registeredUserID = expectedValue
-        
+
         let value = NeuroID.getRegisteredUserID()
-        
+
         assert(NeuroID.registeredUserID == expectedValue)
         assert(value == expectedValue)
-        
+
         NeuroID.registeredUserID = ""
     }
-    
+
     func test_setRegisteredUserID_started() {
         UserDefaults.standard.removeObject(forKey: userIdKey)
-        
+
         let expectedValue = "test_ruid"
-        
+
         let fnSuccess = NeuroID.setRegisteredUserID(expectedValue)
-        
+
         let storedValue = UserDefaults.standard.string(forKey: userIdKey)
-        
+
         assert(fnSuccess == true)
         assert(NeuroID.registeredUserID == expectedValue)
         assert(storedValue == nil)
-        
+
         assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
         assert(DataStore.queuedEvents.count == 0)
-        
+
         NeuroID.registeredUserID = ""
     }
-    
+
     func test_setRegisteredUserID_pre_start() {
         _ = NeuroID.stop()
         UserDefaults.standard.removeObject(forKey: userIdKey)
-        
+
         let expectedValue = "test_ruid"
-        
+
         let fnSuccess = NeuroID.setRegisteredUserID(expectedValue)
-        
+
         let storedValue = UserDefaults.standard.string(forKey: userIdKey)
-        
+
         assert(fnSuccess == true)
         assert(NeuroID.registeredUserID == expectedValue)
         assert(storedValue == nil)
-        
+
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: true)
         NeuroID.registeredUserID = ""
     }
-    
+
     func test_setRegisteredUserID_already_set() {
         clearOutDataStore()
         NeuroID._isSDKStarted = true
         NeuroID.registeredUserID = "setID"
-        
+
         let expectedValue = "test_ruid"
-        
+
         let fnSuccess = NeuroID.setRegisteredUserID(expectedValue)
-        
+
         assert(fnSuccess == false)
         assert(NeuroID.registeredUserID != expectedValue)
-        
+
         assertStoredEventTypeAndCount(type: "LOG", count: 1)
         assert(DataStore.queuedEvents.count == 0)
-        
+
         NeuroID.registeredUserID = ""
     }
-    
+
     func test_setRegisteredUserID_same_value() {
         clearOutDataStore()
-        
+
         let expectedValue = "test_ruid"
-        
+
         NeuroID.registeredUserID = expectedValue
-        
+
         UserDefaults.standard.removeObject(forKey: userIdKey)
-        
+
         let fnSuccess = NeuroID.setRegisteredUserID(expectedValue)
-        
+
         let storedValue = UserDefaults.standard.string(forKey: userIdKey)
-        
+
         assert(fnSuccess == true)
         assert(NeuroID.registeredUserID == expectedValue)
         assert(storedValue == nil)
-        
+
         assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
-        
+
         NeuroID.registeredUserID = ""
     }
-    
+
     func test_attemptedLoginWthUID() {
         let validID = NeuroID.attemptedLogin("valid_user_id")
         assertStoredEventTypeAndCount(type: "ATTEMPTED_LOGIN", count: 1)
@@ -1184,7 +1184,7 @@ class NIDUserTests: XCTestCase {
         // Value shoould be hashed/salted/prefixed
         XCTAssertEqual("valid_user_id", event[0].uid!)
     }
-    
+
     func test_attemptedLoginWthUIDQueued() {
         NeuroID._isSDKStarted = false
         let validID = NeuroID.attemptedLogin("valid_user_id")
@@ -1197,7 +1197,7 @@ class NIDUserTests: XCTestCase {
         // Value shoould be hashed/salted/prefixed
         XCTAssertEqual("valid_user_id", event[0].uid!)
     }
-    
+
     func test_attemptedLoginWithInvalidID() {
         let invalidID = NeuroID.attemptedLogin("🤣")
         let allEvents = DataStore.getAllEvents()
@@ -1207,7 +1207,7 @@ class NIDUserTests: XCTestCase {
         XCTAssertEqual(event[0].uid, "scrubbed-id-failed-validation")
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: false)
     }
-    
+
     func test_attemptedLoginWithInvalidIDQueued() {
         NeuroID._isSDKStarted = false
         let invalidID = NeuroID.attemptedLogin("🤣")
@@ -1218,7 +1218,7 @@ class NIDUserTests: XCTestCase {
         XCTAssertTrue(invalidID)
         XCTAssertEqual(event[0].uid, "scrubbed-id-failed-validation")
     }
-    
+
     func test_attemptedLoginWithNoUID() {
         _ = NeuroID.attemptedLogin()
         assertStoredEventTypeAndCount(type: "ATTEMPTED_LOGIN", count: 1)
@@ -1227,7 +1227,7 @@ class NIDUserTests: XCTestCase {
         XCTAssertEqual(event.last!.uid, "scrubbed-id-failed-validation")
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
     }
-    
+
     func test_attemptedLoginWithNoUIDQueued() {
         NeuroID._isSDKStarted = false
         _ = NeuroID.attemptedLogin()
@@ -1237,7 +1237,7 @@ class NIDUserTests: XCTestCase {
         let event = allEvents.filter { $0.type == "ATTEMPTED_LOGIN" }
         XCTAssertEqual(event.last!.uid, "scrubbed-id-failed-validation")
     }
-    
+
     func test_multipleAttemptedLogins() {
         _ = NeuroID.attemptedLogin()
         _ = NeuroID.attemptedLogin()
@@ -1250,19 +1250,19 @@ class NIDEnvTests: XCTestCase {
         NeuroID.environment = Constants.environmentTest.rawValue
         assert(NeuroID.getEnvironment() == "TEST")
     }
-    
+
     func test_setEnvironmentProduction_true() {
         NeuroID.environment = ""
         NeuroID.setEnvironmentProduction(true)
-        
+
         // Should do nothing because deprecated
         assert(NeuroID.getEnvironment() == "")
     }
-    
+
     func test_setEnvironmentProduction_false() {
         NeuroID.environment = ""
         NeuroID.setEnvironmentProduction(false)
-        
+
         // Should do nothing because deprecated
         assert(NeuroID.getEnvironment() == "")
     }
@@ -1270,104 +1270,104 @@ class NIDEnvTests: XCTestCase {
 
 class NIDClientSiteIdTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-    
+
     // Keys for storage:
     let clientKeyKey = Constants.storageClientKey.rawValue
     let cidKey = Constants.storageClientIDKey.rawValue
-    
+
     func test_getClientID() {
         UserDefaults.standard.setValue("test-cid", forKey: cidKey)
         NeuroID.clientID = nil
         let value = NeuroID.getClientID()
-        
+
         assert(value == "test-cid")
     }
-    
+
     func test_getClientId_existing() {
         let expectedValue = "test-cid"
-        
+
         NeuroID.clientID = expectedValue
         UserDefaults.standard.set(expectedValue, forKey: cidKey)
-        
+
         let value = NeuroID.getClientID()
-        
+
         assert(value == expectedValue)
     }
-    
+
     func test_getClientId_random() {
         let expectedValue = "test_cid"
-        
+
         UserDefaults.standard.set(expectedValue, forKey: cidKey)
-        
+
         let value = NeuroID.getClientID()
-        
+
         assert(value != expectedValue)
     }
-    
+
     func test_getClientKey() {
         NeuroID.clientKey = nil
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
         let expectedValue = clientKey
-        
+
         let value = NeuroID.getClientKey()
-        
+
         assert(value == expectedValue)
     }
-    
+
     func test_getClientKeyFromLocalStorage() {
         let expectedValue = "testClientKey"
-        
+
         UserDefaults.standard.setValue(expectedValue, forKey: clientKeyKey)
-        
+
         let value = NeuroID.getClientKeyFromLocalStorage()
         assert(value == expectedValue)
     }
-    
+
     func test_setSiteId() {
         NeuroID.setSiteId(siteId: "test_site")
-        
+
         assert(NeuroID.siteID == "test_site")
     }
-    
+
     func test_validateClientKey_valid_live() {
         let value = NeuroID.validateClientKey("key_live_XXXXXXXXXXX")
-        
+
         assert(value)
     }
-    
+
     func test_validateClientKey_valid_test() {
         let value = NeuroID.validateClientKey("key_test_XXXXXXXXXXX")
-        
+
         assert(value)
     }
-    
+
     func test_validateClientKey_invalid_env() {
         let value = NeuroID.validateClientKey("key_foo_XXXXXXXXXXX")
-        
+
         assert(!value)
     }
-    
+
     func test_validateClientKey_invalid_random() {
         let value = NeuroID.validateClientKey("sdfsdfsdfsdf")
-        
+
         assert(!value)
     }
-    
+
     func test_validateSiteID_valid() {
         let value = NeuroID.validateSiteID("form_peaks345")
-        
+
         assert(value)
     }
-    
+
     func test_validateSiteID_invalid_bad() {
         let value = NeuroID.validateSiteID("badSiteID")
-        
+
         assert(!value)
     }
-    
+
     func test_validateSiteID_invalid_short() {
         let value = NeuroID.validateSiteID("form_abc123")
-        
+
         assert(!value)
     }
 }
@@ -1375,63 +1375,63 @@ class NIDClientSiteIdTests: XCTestCase {
 class NIDSendTests: XCTestCase {
     func test_getCollectionEndpointURL() {
         let expectedValue = "https://receiver.neuro-dev.com/c"
-        
+
         let value = NeuroID.getCollectionEndpointURL()
         assert(value == expectedValue)
     }
-    
+
     func test_initCollectionTimer_item() {
         NeuroID._isSDKStarted = false
         let expectation = XCTestExpectation(description: "Wait for 5 seconds")
-        
+
         let workItem = DispatchWorkItem {
             NeuroID._isSDKStarted = true
             expectation.fulfill()
         }
         NeuroID.sendCollectionWorkItem = workItem
-        
+
         NeuroID.initCollectionTimer()
-        
+
         // Wait for the expectation to be fulfilled, or timeout after 7 seconds
         wait(for: [expectation], timeout: 7)
-        
+
         assert(NeuroID._isSDKStarted)
         NeuroID._isSDKStarted = false
     }
-    
+
     func test_initCollectionTimer_item_nil() {
         NeuroID._isSDKStarted = false
         let expectation = XCTestExpectation(description: "Wait for 5 seconds")
-        
+
         // setting the item as nil so the queue won't run
         NeuroID.sendCollectionWorkItem = nil
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
             expectation.fulfill()
         }
-        
+
         NeuroID.initCollectionTimer()
-        
+
         // Wait for the expectation to be fulfilled, or timeout after 7 seconds
         wait(for: [expectation], timeout: 7)
-        
+
         assert(!NeuroID._isSDKStarted)
         NeuroID._isSDKStarted = false
     }
-    
+
     //    createCollectionWorkItem // Not sure how to test because it returns an item that always exists
 }
 
 class NIDLogTests: XCTestCase {
     func test_enableLogging_true() {
         NeuroID.enableLogging(true)
-        
+
         assert(NeuroID.showLogs)
     }
-    
+
     func test_enableLogging_false() {
         NeuroID.enableLogging(false)
-        
+
         assert(!NeuroID.showLogs)
     }
 }
@@ -1441,76 +1441,76 @@ class NIDRNTests: XCTestCase {
         NeuroID.isRN = false
         NeuroID.clientKey = nil
     }
-    
+
     let configOptionsTrue = [RNConfigOptions.usingReactNavigation.rawValue: true, RNConfigOptions.isAdvancedDevice.rawValue: false]
     let configOptionsFalse = [RNConfigOptions.usingReactNavigation.rawValue: false]
     let configOptionsInvalid = ["foo": "bar"]
-    
+
     func assertConfigureTests(defaultValue: Bool, expectedValue: Bool) {
         assert(NeuroID.isRN)
         let storedValue = NeuroID.rnOptions[.usingReactNavigation] as? Bool ?? defaultValue
         assert(storedValue == expectedValue)
         assert(NeuroID.rnOptions.count == 1)
     }
-    
+
     func test_isRN() {
         assert(!NeuroID.isRN)
         NeuroID.setIsRN()
-        
+
         assert(NeuroID.isRN)
     }
-    
+
     func test_configure_usingReactNavigation_true() {
         assert(!NeuroID.isRN)
         let configured = NeuroID.configure(
             clientKey: "key_test_XXXXXXXXXXX",
             rnOptions: configOptionsTrue
         )
-        
+
         assert(configured)
         assertConfigureTests(defaultValue: false, expectedValue: true)
     }
-    
+
     func test_configure_usingReactNavigation_false() {
         assert(!NeuroID.isRN)
         let configured = NeuroID.configure(
             clientKey: "key_test_XXXXXXXXXXX",
             rnOptions: configOptionsFalse
         )
-        
+
         assert(configured)
         assertConfigureTests(defaultValue: true, expectedValue: false)
     }
-    
+
     func test_configure_invalid_key() {
         assert(!NeuroID.isRN)
         let configured = NeuroID.configure(
             clientKey: "key_test_XXXXXXXXXXX",
             rnOptions: configOptionsInvalid
         )
-        
+
         assert(configured)
         assertConfigureTests(defaultValue: true, expectedValue: false)
     }
-    
+
     func test_getOptionValueBool_true() {
         assert(!NeuroID.isRN)
         let value = NeuroID.getOptionValueBool(rnOptions: configOptionsTrue, configOptionKey: .usingReactNavigation)
-        
+
         assert(value)
     }
-    
+
     func test_getOptionValueBool_false() {
         assert(!NeuroID.isRN)
         let value = NeuroID.getOptionValueBool(rnOptions: configOptionsFalse, configOptionKey: .usingReactNavigation)
-        
+
         assert(!value)
     }
-    
+
     func test_getOptionValueBool_invalid() {
         assert(!NeuroID.isRN)
         let value = NeuroID.getOptionValueBool(rnOptions: configOptionsInvalid, configOptionKey: .usingReactNavigation)
-        
+
         assert(!value)
     }
 }

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -517,9 +517,9 @@ class NIDNewSessionTests: XCTestCase {
             self.assertSessionStartedTests(sessionRes)
             assert(expectedValue == sessionRes.sessionID)
         }
-        // TODO-How are events showing up in Datastore and not Queue
+        
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
     }
     
@@ -532,9 +532,9 @@ class NIDNewSessionTests: XCTestCase {
             self.assertSessionStartedTests(sessionRes)
             assert(expectedValue != sessionRes.sessionID)
         }
-        // TODO-How are events showing up in Datastore and not Queue
+        
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
     }
     
@@ -548,7 +548,7 @@ class NIDNewSessionTests: XCTestCase {
             assert(expectedValue != sessionRes.sessionID)
         }
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
     }
     
@@ -562,7 +562,7 @@ class NIDNewSessionTests: XCTestCase {
             assert(expectedValue == sessionRes.sessionID)
         }
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
     }
     
@@ -582,7 +582,7 @@ class NIDNewSessionTests: XCTestCase {
             self.assertSessionNotStartedTests(sessionRes)
         }
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
-        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: true)
     }
     
@@ -906,7 +906,7 @@ class NIDUserTests: XCTestCase {
         
         assert(result == true)
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assert(DataStore.queuedEvents.count == 0)
     }
     
@@ -920,7 +920,7 @@ class NIDUserTests: XCTestCase {
         assert(result == true)
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
     }
     
     func test_setGenericUserID_valid_registered_id_started() {
@@ -931,7 +931,7 @@ class NIDUserTests: XCTestCase {
         
         assert(result == true)
         assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assert(DataStore.queuedEvents.count == 0)
     }
     
@@ -945,7 +945,7 @@ class NIDUserTests: XCTestCase {
         assert(result == true)
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
-        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
     }
     
     func test_setGenericUserID_invalid_id_started() {
@@ -956,7 +956,7 @@ class NIDUserTests: XCTestCase {
         
         assert(result == false)
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: false)
     }
     
@@ -970,7 +970,7 @@ class NIDUserTests: XCTestCase {
         assert(result == false)
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
-        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: true)
     }
     
@@ -988,7 +988,7 @@ class NIDUserTests: XCTestCase {
         assert(storedValue == nil)
         
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
         
         assert(DataStore.queuedEvents.count == 0)
@@ -1010,7 +1010,7 @@ class NIDUserTests: XCTestCase {
         
         //        assert(DataStore.events.count == 0) "NETWORK_STATE" event present
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: true)
     }
     
@@ -1028,7 +1028,7 @@ class NIDUserTests: XCTestCase {
         assert(storedValue == nil)
         
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
         
         assert(DataStore.queuedEvents.count == 0)
@@ -1050,7 +1050,7 @@ class NIDUserTests: XCTestCase {
         
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: true)
     }
     
@@ -1108,7 +1108,7 @@ class NIDUserTests: XCTestCase {
         assert(storedValue == nil)
         
         assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
         assert(DataStore.queuedEvents.count == 0)
         
@@ -1131,7 +1131,7 @@ class NIDUserTests: XCTestCase {
         
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
-        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 3)
+        assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: true)
         NeuroID.registeredUserID = ""
     }

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -169,11 +169,11 @@ class NeuroIDClassTests: XCTestCase {
             assert(started)
             assert(NeuroID.isSDKStarted)
             
-            assert(DataStore.events.count == 6)
+            assert(DataStore.events.count == 7)
             self.assertStoredEventCount(type: "CREATE_SESSION", count: 1)
             self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 1)
             self.assertStoredEventCount(type: "SET_USER_ID", count: 1)
-            self.assertStoredEventCount(type: "SET_VARIABLE", count: 3)
+            self.assertStoredEventCount(type: "SET_VARIABLE", count: 4)
         }
     }
     


### PR DESCRIPTION
Refactoring the way Session ID origin event is sent to avoid sending duplicate SET_VARIABLE events. Creating an internal setUserID() method to allow a `userGenerated` flag. Updating the public setUsetID method to call the internal method with `userGenerated` flag defaulting to true.