### PR TITLE
ENG-8365 - Update logic to get the screenHierarchy, add topDown and bottomUp path for verification

### DIFF
--- a/NeuroID/NIDEvent.swift
+++ b/NeuroID/NIDEvent.swift
@@ -477,10 +477,9 @@ public class NIDEvent: Codable {
 
         self.type = type.rawValue
         self.ts = ParamsCreator.getTimeStamp()
-        self.url = UtilFunctions.getFullViewlURLPath(
-            currView: view,
-            screenName: NeuroID.getScreenName() ?? view?.nidClassName ?? ""
-        )
+        self.url = view != nil ? UtilFunctions.getFullViewlURLPath(
+            currView: view!
+        ) : NeuroID.getScreenName() ?? view?.nidClassName ?? ""
 
         self.tgs = viewId.toString()
         self.tg = newTg

--- a/NeuroID/NeuroIDClass/Extensions/NIDRegistration.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDRegistration.swift
@@ -18,23 +18,47 @@ public extension NeuroID {
         NeuroID.excludeViewByTestID(excludedView)
     }
 
+    /**
+        Specifically available for the React Native SDK to call and register all page targets due to lifecycle event delays
+     */
+    static func registerPageTargets() {
+        if let viewController = UIApplication.shared.keyWindow?.rootViewController {
+            DispatchQueue.main.async {
+                viewController.registerPageTargets()
+            }
+        }
+    }
+
+    @available(*, deprecated, message: "manuallyRegisterTarget is deprecated and no longer used")
     /** Public API for manually registering a target. This should only be used when automatic fails. */
     static func manuallyRegisterTarget(view: UIView) {
         let screenName = view.id
         let guid = ParamsCreator.generateID()
         NIDLog.d(tag: "\(Constants.registrationTag.rawValue)", "Registering single view: \(screenName)")
-        NeuroIDTracker.registerSingleView(v: view, screenName: screenName, guid: guid)
+        NeuroIDTracker.registerSingleView(
+            v: view,
+            screenName: screenName,
+            guid: guid,
+            topDownHierarchyPath: ""
+        )
         let childViews = view.subviewsRecursive()
+
         for _view in childViews {
             NIDLog.d(tag: "\(Constants.registrationTag.rawValue)", "Registering subview Parent: \(screenName) Child: \(_view)")
-            NeuroIDTracker.registerSingleView(v: _view, screenName: screenName, guid: guid)
+            NeuroIDTracker.registerSingleView(
+                v: _view,
+                screenName: screenName,
+                guid: guid,
+                topDownHierarchyPath: ""
+            )
         }
     }
 
-    /** React Native API for manual registration */
+    @available(*, deprecated, message: "manuallyRegisterRNTarget is deprecated and no longer used")
+    /** React Native API for manual registration - DEPRECATED */
     static func manuallyRegisterRNTarget(id: String, className: String, screenName: String, placeHolder: String) -> NIDEvent {
         let guid = ParamsCreator.generateID()
-        let fullViewString = UtilFunctions.getFullViewlURLPath(currView: nil, screenName: screenName)
+        let fullViewString = screenName
 
         let nidEvent = NIDEvent(type: .registerTarget)
         nidEvent.tgs = id

--- a/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/NeuroID/NeuroIDClass/NeuroID.swift
@@ -157,14 +157,6 @@ public class NeuroID: NSObject {
         return _isSDKStarted != true
     }
 
-    public static func registerPageTargets() {
-        if let viewController = UIApplication.shared.keyWindow?.rootViewController {
-            DispatchQueue.main.async {
-                viewController.registerPageTargets()
-            }
-        }
-    }
-
     static func checkThenCaptureAdvancedDevice(_ shouldCapture: Bool = NeuroID.isAdvancedDevice) {
         let selectorString = "captureAdvancedDevice:"
         let selector = NSSelectorFromString(selectorString)

--- a/NeuroID/NeuroIDTracker.swift
+++ b/NeuroID/NeuroIDTracker.swift
@@ -33,21 +33,31 @@ public class NeuroIDTracker: NSObject {
         DataStore.insertEvent(screen: screenName, event: newEvent)
     }
     
-    public static func registerSingleView(v: Any, screenName: String, guid: String, rts: Bool? = false) {
+    public static func registerSingleView(
+        v: Any,
+        screenName: String,
+        guid: String,
+        rts: Bool? = false,
+        topDownHierarchyPath: String
+    ) {
         let currView = v as? UIView
         
         // constants
         let screenName = NeuroID.getScreenName() ?? screenName
-        let fullViewString = UtilFunctions.getFullViewlURLPath(currView: currView, screenName: screenName)
+        let bottomUpHierarchyPath = UtilFunctions.getFullViewlURLPath(currView: currView ?? UIView())
+        
         let baseAttrs = [
             Attrs(n: "\(Constants.attrGuidKey.rawValue)", v: guid),
-            Attrs(n: "\(Constants.attrScreenHierarchyKey.rawValue)", v: fullViewString),
+            Attrs(n: "\(Constants.attrScreenHierarchyKey.rawValue)", v: bottomUpHierarchyPath),
+            Attrs(n: "top-\(Constants.attrScreenHierarchyKey.rawValue)", v: topDownHierarchyPath),
         ]
+        
         let tg = [
             "\(Constants.attrKey.rawValue)": TargetValue.attr(
                 [
-                    Attr(n: "\(Constants.attrScreenHierarchyKey.rawValue)", v: fullViewString),
+                    Attr(n: "\(Constants.attrScreenHierarchyKey.rawValue)", v: bottomUpHierarchyPath),
                     Attr(n: "\(Constants.attrGuidKey.rawValue)", v: guid),
+                    Attr(n: "top-\(Constants.attrScreenHierarchyKey.rawValue)", v: topDownHierarchyPath),
                 ]
             ),
         ]
@@ -168,10 +178,10 @@ public class NeuroIDTracker: NSObject {
             case is UITableViewCell:
                 // swiftUI list
                 let element = v as! UITableViewCell
-                NIDLog.d(tag: "NeuroID FE:", "TABLE View Found NOT Registered: \(element.nidClassName) - \(element.id)-")
+                NIDLog.d(tag: "NeuroID FE:", "Table View Found NOT Registered: \(element.nidClassName) - \(element.id)-")
             case is UIScrollView:
                 let element = v as! UIScrollView
-                NIDLog.d(tag: "NeuroID FE:", "SCROLL View Found NOT Registered: \(element.nidClassName) - \(element.id)-")
+                NIDLog.d(tag: "NeuroID FE:", "Scroll View Found NOT Registered: \(element.nidClassName) - \(element.id)-")
                 
             default:
                 if !found {
@@ -209,7 +219,14 @@ public class NeuroIDTracker: NSObject {
         if !NeuroID.registeredTargets.contains(view.id) {
             NeuroID.registeredTargets.append(view.id)
             let guid = ParamsCreator.generateID()
-            NeuroIDTracker.registerSingleView(v: view, screenName: NeuroID.getScreenName() ?? view.nidClassName, guid: guid, rts: true)
+            
+            NeuroIDTracker.registerSingleView(
+                v: view,
+                screenName: NeuroID.getScreenName() ?? view.nidClassName,
+                guid: guid,
+                rts: true,
+                topDownHierarchyPath: ""
+            )
             return true
         }
         return false

--- a/NeuroID/TrackerClassExtensions/UIClassExtensions/UITableView.swift
+++ b/NeuroID/TrackerClassExtensions/UIClassExtensions/UITableView.swift
@@ -22,7 +22,7 @@ private func tableViewSwizzling(element: UITableView.Type,
     }
 }
 
-internal extension UITableView {
+extension UITableView {
     static func tableviewSwizzle() {
         let table = UITableView.self
         tableViewSwizzling(element: table, originalSelector: #selector(table.reloadData), swizzledSelector: #selector(table.neuroIDReloadData))
@@ -43,7 +43,11 @@ internal extension UITableView {
             let childViews = cell.contentView.subviewsRecursive()
             for _view in childViews {
                 NIDLog.d(tag: "\(Constants.registrationTag.rawValue)", "Registering single view for cell.")
-                NeuroIDTracker.registerSingleView(v: _view, screenName: cellName, guid: guid)
+                NeuroIDTracker.registerSingleView(
+                    v: _view,
+                    screenName: cellName,
+                    guid: guid,
+                    topDownHierarchyPath: "\(nidClassName)/\(cellName)")
             }
         }
     }

--- a/NeuroID/TrackerClassExtensions/UIClassExtensions/UIView.swift
+++ b/NeuroID/TrackerClassExtensions/UIClassExtensions/UIView.swift
@@ -16,6 +16,20 @@ import UIKit
  */
 
 extension UIView {
+    /**
+        This attribute will navigate up the elements responder tree until a UIViewController that is responsible for the UIView is found.
+     */
+    var viewController: UIViewController? {
+        var responder: UIResponder? = self
+        while let currentResponder = responder {
+            responder = currentResponder.next
+            if let viewController = currentResponder as? UIViewController {
+                return viewController
+            }
+        }
+        return nil
+    }
+
     func subviewsRecursive() -> [Any] {
         return subviews + subviews.flatMap { $0.subviewsRecursive() }
     }
@@ -48,7 +62,7 @@ public extension UIView {
             } else if let textControl = self as? UIDatePicker {
                 backupName = "\(textControl.hash)"
             } else if let textControl = self as? UIButton {
-                backupName = "\(textControl.hash)"
+                backupName = "\(textControl.titleLabel?.text ?? "")-\(textControl.hash)"
             } else if let textControl = self as? UISlider {
                 backupName = "\(textControl.hash)"
             } else if let textControl = self as? UISegmentedControl {

--- a/NeuroID/TrackerClassExtensions/UIClassExtensions/UIViewController.swift
+++ b/NeuroID/TrackerClassExtensions/UIClassExtensions/UIViewController.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-internal func uiViewSwizzling(
+func uiViewSwizzling(
     viewController: UIViewController.Type,
     originalSelector: Selector,
     swizzledSelector: Selector
@@ -93,7 +93,7 @@ extension UIViewController {
     }
 }
 
-internal extension UIViewController {
+extension UIViewController {
     private var registerViews: [String]? {
         get {
             return UserDefaults(suiteName: "ViewHierarchy")?.object(forKey: "registerViews") as? [String]
@@ -159,7 +159,6 @@ internal extension UIViewController {
     }
 
     @objc func registerPageTargets() {
-
         if ignoreLists.contains(nidClassName) { return }
 
         // check if its RN, using the React Navigation Package, and Matching the ClassName
@@ -172,9 +171,7 @@ internal extension UIViewController {
         // We need to init the tracker on the views.
         tracker
 
-        var allViewControllers = children.filter { !ignoreLists.contains($0.nidClassName) }
-        allViewControllers.append(self)
-        UtilFunctions.registerSubViewsTargets(subViewControllers: allViewControllers)
+        UtilFunctions.registerSubViewsTargets(controller: self)
         registerViews = view.subviewsDescriptions
 
         NeuroID.registerKeyboardListener(className: nidClassName, view: self)

--- a/SDKTest/NIDEventTests.swift
+++ b/SDKTest/NIDEventTests.swift
@@ -33,8 +33,13 @@ class NIDEventTests: XCTestCase {
         touchesNil: Bool = true)
     {
         assert(nidEvent.type == eventType.rawValue)
+        
+        if (nidEvent.url?.hasPrefix("/")) == true {
+            assert(nidEvent.url == "/\(screenName)")
+        } else {
+            assert(nidEvent.url == screenName)
+        }
 
-        assert(nidEvent.url == screenName)
         assert(nidEvent.tgs == tgs)
         
         assert(nidEvent.tg != nil)
@@ -314,7 +319,7 @@ class NIDEventTests: XCTestCase {
     }
     
     func test_init_6_2_1() {
-        let screenName = "myTestScreenName"
+        let screenName = "UIView"
         NeuroID.currentScreenName = screenName
         
         let uiId = "testUIViewId"

--- a/SDKTest/NeuroIDTrackerTests.swift
+++ b/SDKTest/NeuroIDTrackerTests.swift
@@ -113,7 +113,7 @@ class NeuroIDTrackerTests: XCTestCase {
     func test_registerSingleView_UITextField() {
         let uiView = UITextField()
         
-        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue)
+        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue, topDownHierarchyPath: "")
         
         assertViewRegistered(v: uiView)
     }
@@ -121,7 +121,7 @@ class NeuroIDTrackerTests: XCTestCase {
     func test_registerSingleView_UITextView() {
         let uiView = UITextView()
         
-        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue)
+        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue, topDownHierarchyPath: "")
         
         assertViewRegistered(v: uiView)
     }
@@ -129,7 +129,7 @@ class NeuroIDTrackerTests: XCTestCase {
     func test_registerSingleView_UIButton() {
         let uiView = UIButton()
         
-        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue)
+        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue, topDownHierarchyPath: "")
         
         assertViewRegistered(v: uiView)
     }
@@ -137,7 +137,7 @@ class NeuroIDTrackerTests: XCTestCase {
     func test_registerSingleView_UISlider() {
         let uiView = UISlider()
         
-        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue)
+        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue, topDownHierarchyPath: "")
         
         assertViewRegistered(v: uiView)
     }
@@ -145,7 +145,7 @@ class NeuroIDTrackerTests: XCTestCase {
     func test_registerSingleView_UISwitch() {
         let uiView = UISwitch()
         
-        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue)
+        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue, topDownHierarchyPath: "")
         
         assertViewRegistered(v: uiView)
     }
@@ -153,7 +153,7 @@ class NeuroIDTrackerTests: XCTestCase {
     func test_registerSingleView_UIDatePicker() {
         let uiView = UIDatePicker()
         
-        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue)
+        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue, topDownHierarchyPath: "")
         
         assertViewRegistered(v: uiView)
     }
@@ -161,7 +161,7 @@ class NeuroIDTrackerTests: XCTestCase {
     func test_registerSingleView_UIStepper() {
         let uiView = UIStepper()
         
-        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue)
+        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue, topDownHierarchyPath: "")
         
         assertViewRegistered(v: uiView)
         
@@ -171,7 +171,7 @@ class NeuroIDTrackerTests: XCTestCase {
     func test_registerSingleView_UISegmentedControl() {
         let uiView = UISegmentedControl()
         
-        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue)
+        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue, topDownHierarchyPath: "")
         
         assertViewRegistered(v: uiView)
     }
@@ -179,7 +179,7 @@ class NeuroIDTrackerTests: XCTestCase {
     func test_registerSingleView_NOT_UIPickerView() {
         let uiView = UIPickerView()
         
-        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue)
+        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue, topDownHierarchyPath: "")
         
         assertViewNOTRegistered(v: uiView)
     }
@@ -187,7 +187,7 @@ class NeuroIDTrackerTests: XCTestCase {
     func test_registerSingleView_NOT_UITableViewCell() {
         let uiView = UITableViewCell()
         
-        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue)
+        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue, topDownHierarchyPath: "")
         
         assertViewNOTRegistered(v: uiView)
     }
@@ -195,7 +195,7 @@ class NeuroIDTrackerTests: XCTestCase {
     func test_registerSingleView_NOT_UIScrollView() {
         let uiView = UIScrollView()
         
-        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue)
+        NeuroIDTracker.registerSingleView(v: uiView, screenName: screenNameValue, guid: guidValue, topDownHierarchyPath: "")
         
         assertViewNOTRegistered(v: uiView)
     }

--- a/SDKTest/UIViewExtensionTests.swift
+++ b/SDKTest/UIViewExtensionTests.swift
@@ -112,7 +112,7 @@ class UIViewExtensionTests: XCTestCase {
 
         runThroughBasicUIViewTests(uiView: uiView, className: className)
 
-        assertViewIdEqualsWithHash(uiView, expectedClass: className, hash: "\(uiView.hash)")
+        assertViewIdEqualsWithHash(uiView, expectedClass: className, hash: "-\(uiView.hash)")
     }
 
     func test_uiview_id_UISlider() {

--- a/SDKTest/UtilFunctionsTests.swift
+++ b/SDKTest/UtilFunctionsTests.swift
@@ -44,21 +44,13 @@ final class UtilFunctionsTests: XCTestCase {
         assert(rEvents.count == expectedCount)
     }
 
-    func test_getFullViewlURLPath_no_view() {
-        let expectedValue = screenNameValue
-
-        let value = UtilFunctions.getFullViewlURLPath(currView: nil, screenName: expectedValue)
-
-        assert(value == expectedValue)
-    }
-
-    func test_getFullViewlURLPath_no_parent() {
+    func test_getFullViewlURLPath() {
         let expectedValue = screenNameValue
         let uiView = UIView()
 
-        let value = UtilFunctions.getFullViewlURLPath(currView: uiView, screenName: expectedValue)
+        let value = UtilFunctions.getFullViewlURLPath(currView: uiView)
 
-        assert(value == expectedValue)
+        assert(value == "/\(uiView.nidClassName)")
     }
 
     func test_registerField() {


### PR DESCRIPTION
From Top Controller:
```
 top-screenHierarchy:BaseNavigation/UINavigation/UITextField
 bot-screenHierarchy:/BaseNavigation/UINavigation/UITextField 
```


From Mid-Level Controller:
```
 top-screenHierarchy:UINavigation/UITextField
 bot-screenHierarchy:/BaseNavigation/UINavigation/UITextField  
```