### PR TITLE
ENG-8297 Log events and scrub user ID before logging

### DIFF
--- a/NeuroID/NeuroIDClass/Extensions/NIDSend.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSend.swift
@@ -145,12 +145,8 @@ extension NeuroID {
             }, onFailure: { error in
                 logError(category: "APICall", content: String(describing: error))
                 let sendEventsLogEvent = NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Group and POST failure: \(error)")
-
-                if !NeuroID.isSDKStarted {
-                    saveQueuedEventToLocalDataStore(sendEventsLogEvent)
-                } else {
-                    saveEventToLocalDataStore(sendEventsLogEvent)
-                }
+                saveEventToDataStore(sendEventsLogEvent)
+                
                 completion()
             }
         )

--- a/NeuroID/NeuroIDClass/Extensions/NIDSend.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSend.swift
@@ -144,6 +144,13 @@ extension NeuroID {
                 completion()
             }, onFailure: { error in
                 logError(category: "APICall", content: String(describing: error))
+                let sendEventsLogEvent = NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Group and POST failure: \(error)")
+
+                if !NeuroID.isSDKStarted {
+                    saveQueuedEventToLocalDataStore(sendEventsLogEvent)
+                } else {
+                    saveEventToLocalDataStore(sendEventsLogEvent)
+                }
                 completion()
             }
         )

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -69,7 +69,7 @@ public extension NeuroID {
         let closeEvent = NIDEvent(type: NIDEventName.closeSession)
         closeEvent.ct = "SDK_EVENT"
         saveEventToLocalDataStore(closeEvent)
-        
+
         let stopSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Stop session attempt")
         saveEventToLocalDataStore(stopSessionLogEvent)
 
@@ -196,15 +196,15 @@ extension NeuroID {
     static func closeSession(skipStop: Bool = false) throws -> NIDEvent {
         let closeSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Close session attempt")
         saveEventToDataStore(closeSessionLogEvent)
-        
+
         if !NeuroID.isSDKStarted {
-            saveEventToDataStore(NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Close attempt failed since SDK is not started"))
+            saveQueuedEventToLocalDataStore(NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Close attempt failed since SDK is not started"))
             throw NIDError.sdkNotStarted
         }
 
         let closeEvent = NIDEvent(type: NIDEventName.closeSession)
         closeEvent.ct = "SDK_EVENT"
-        saveEventToDataStore(closeEvent)
+        saveEventToLocalDataStore(closeEvent)
 
         if skipStop {
             return closeEvent
@@ -340,7 +340,7 @@ extension NeuroID {
         let userGenerated = sessionID != nil
 
         let finalSessionID = sessionID ?? ParamsCreator.generateID()
-        
+
         let startSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Start session attempt with siteID: \(siteID ?? "") and sessionID: \(scrubIdentifier(identifier: finalSessionID))")
         saveEventToDataStore(startSessionLogEvent)
 

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -69,6 +69,9 @@ public extension NeuroID {
         let closeEvent = NIDEvent(type: NIDEventName.closeSession)
         closeEvent.ct = "SDK_EVENT"
         saveEventToLocalDataStore(closeEvent)
+        let stopSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Stop session attempt")
+
+        saveEventToLocalDataStore(stopSessionLogEvent)
 
         pauseCollection()
 
@@ -91,6 +94,15 @@ public extension NeuroID {
         userID: String? = nil,
         completion: @escaping (SessionStartResult) -> Void = { _ in }
     ) {
+        let scrubbedId = (userID != nil) ? scrubIdentifier(identifier: userID!) : "null"
+        let startSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "StartAppFlow attempt with siteID: \(siteID), userID: \(scrubbedId))")
+
+        if !NeuroID.isSDKStarted {
+            saveQueuedEventToLocalDataStore(startSessionLogEvent)
+        } else {
+            saveEventToLocalDataStore(startSessionLogEvent)
+        }
+
         if !NeuroID.verifyClientKeyExists() || !NeuroID.validateSiteID(siteID) {
             let res = SessionStartResult(false, "")
 
@@ -309,6 +321,14 @@ extension NeuroID {
         sessionID: String? = nil,
         completion: @escaping (SessionStartResult) -> Void = { _ in }
     ) {
+        let startSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Start attempt with siteID: \(siteID ?? ""))")
+
+        if !NeuroID.isSDKStarted {
+            saveQueuedEventToLocalDataStore(startSessionLogEvent)
+        } else {
+            saveEventToLocalDataStore(startSessionLogEvent)
+        }
+
         if !NeuroID.verifyClientKeyExists() {
             let res = SessionStartResult(false, "")
 

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -200,7 +200,15 @@ extension NeuroID {
     }
 
     static func closeSession(skipStop: Bool = false) throws -> NIDEvent {
+        let closeSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Close session attempt")
+
         if !NeuroID.isSDKStarted {
+            saveQueuedEventToLocalDataStore(closeSessionLogEvent)
+        } else {
+            saveEventToLocalDataStore(closeSessionLogEvent)
+        }
+        if !NeuroID.isSDKStarted {
+            saveQueuedEventToLocalDataStore(NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Close attempt failed since SDK is not started"))
             throw NIDError.sdkNotStarted
         }
 
@@ -294,6 +302,14 @@ extension NeuroID {
         siteID: String?,
         completion: @escaping (Bool) -> Void = { _ in }
     ) {
+        let startLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Start attempt with siteID: \(siteID ?? ""))")
+
+        if !NeuroID.isSDKStarted {
+            saveQueuedEventToLocalDataStore(startLogEvent)
+        } else {
+            saveEventToLocalDataStore(startLogEvent)
+        }
+
         if !NeuroID.verifyClientKeyExists() {
             completion(false)
             return
@@ -321,7 +337,7 @@ extension NeuroID {
         sessionID: String? = nil,
         completion: @escaping (SessionStartResult) -> Void = { _ in }
     ) {
-        let startSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Start attempt with siteID: \(siteID ?? ""))")
+        let startSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Start session attempt with siteID: \(siteID ?? ""))")
 
         if !NeuroID.isSDKStarted {
             saveQueuedEventToLocalDataStore(startSessionLogEvent)

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -70,7 +70,7 @@ public extension NeuroID {
         closeEvent.ct = "SDK_EVENT"
         saveEventToLocalDataStore(closeEvent)
 
-        let stopSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Stop session attempt")
+        let stopSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "INFO", m: "Stop session attempt")
         saveEventToLocalDataStore(stopSessionLogEvent)
 
         pauseCollection()
@@ -94,7 +94,7 @@ public extension NeuroID {
         userID: String? = nil,
         completion: @escaping (SessionStartResult) -> Void = { _ in }
     ) {
-        let startSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "StartAppFlow attempt with siteID: \(siteID), userID: \(scrubIdentifier(identifier: userID ?? "null")))")
+        let startSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "INFO", m: "StartAppFlow attempt with siteID: \(siteID), userID: \(scrubIdentifier(identifier: userID ?? "null")))")
         saveEventToDataStore(startSessionLogEvent)
 
         if !NeuroID.verifyClientKeyExists() || !NeuroID.validateSiteID(siteID) {
@@ -194,7 +194,7 @@ extension NeuroID {
     }
 
     static func closeSession(skipStop: Bool = false) throws -> NIDEvent {
-        let closeSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Close session attempt")
+        let closeSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "INFO", m: "Close session attempt")
         saveEventToDataStore(closeSessionLogEvent)
 
         if !NeuroID.isSDKStarted {
@@ -294,7 +294,7 @@ extension NeuroID {
         siteID: String?,
         completion: @escaping (Bool) -> Void = { _ in }
     ) {
-        let startLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Start attempt with siteID: \(siteID ?? ""))")
+        let startLogEvent = NIDEvent(type: NIDEventName.log, level: "INFO", m: "Start attempt with siteID: \(siteID ?? ""))")
         saveEventToDataStore(startLogEvent)
 
         if !NeuroID.verifyClientKeyExists() {
@@ -341,7 +341,7 @@ extension NeuroID {
 
         let finalSessionID = sessionID ?? ParamsCreator.generateID()
 
-        let startSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Start session attempt with siteID: \(siteID ?? "") and sessionID: \(scrubIdentifier(identifier: finalSessionID))")
+        let startSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "INFO", m: "Start session attempt with siteID: \(siteID ?? "") and sessionID: \(scrubIdentifier(identifier: finalSessionID))")
         saveEventToDataStore(startSessionLogEvent)
 
         if !setUserID(finalSessionID, userGenerated) {

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -69,8 +69,8 @@ public extension NeuroID {
         let closeEvent = NIDEvent(type: NIDEventName.closeSession)
         closeEvent.ct = "SDK_EVENT"
         saveEventToLocalDataStore(closeEvent)
+        
         let stopSessionLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Stop session attempt")
-
         saveEventToLocalDataStore(stopSessionLogEvent)
 
         pauseCollection()

--- a/NeuroID/NeuroIDClass/Extensions/NIDUser.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDUser.swift
@@ -33,7 +33,7 @@ public extension NeuroID {
     
     internal static func setGenericUserID(type: UserIDTypes, genericUserID: String, userGenerated: Bool = true) -> Bool {
         let validID = validateUserID(genericUserID)
-            
+        
         let originRes = getOriginResult(idValue: genericUserID, validID: validID, userGenerated: userGenerated, idType: type)
         sendOriginEvent(originResult: originRes)
             
@@ -180,9 +180,9 @@ public extension NeuroID {
             let ssnRegex = try NSRegularExpression(pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b")
             var result = emailRegex.matches(in: identifier, range: NSMakeRange(0, identifier.count))
             if !result.isEmpty {
-                let atIndex = identifier.firstIndex(of: "@") ?? identifier.index(before: identifier.endIndex)
+                let atIndex = identifier.firstIndex(of: "@") ?? identifier.endIndex
                 let idLength = identifier.distance(from: identifier.startIndex, to: atIndex)
-                let scrubbedEmailId = String(repeating: "*", count: idLength) + identifier[atIndex...]
+                let scrubbedEmailId = String(identifier.prefix(1)) + String(repeating: "*", count: idLength - 1) + identifier[atIndex...]
                 return scrubbedEmailId
             }
             result = ssnRegex.matches(in: identifier, range: NSMakeRange(0, identifier.count))

--- a/NeuroID/NeuroIDClass/Extensions/NIDUser.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDUser.swift
@@ -38,12 +38,8 @@ public extension NeuroID {
         sendOriginEvent(originResult: originRes)
             
         if !validID {
-            let saveIdFailureEvent = NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Failed to save genericUserID event:\(genericUserID)")
-            if !NeuroID.isSDKStarted {
-                saveQueuedEventToLocalDataStore(saveIdFailureEvent)
-            } else {
-                saveEventToLocalDataStore(saveIdFailureEvent)
-            }
+            let saveIdFailureEvent = NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Failed to save genericUserID event:\(scrubIdentifier(identifier: genericUserID))")
+            saveEventToDataStore(saveIdFailureEvent)
             return false
         }
             
@@ -120,12 +116,7 @@ public extension NeuroID {
     internal static func setUserID(_ userId: String, _ userGenerated: Bool) -> Bool {
 //        Save log event
         let setUserIdLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Set User Id Attempt: \(scrubIdentifier(identifier: userId))")
-        
-        if !NeuroID.isSDKStarted {
-            saveQueuedEventToLocalDataStore(setUserIdLogEvent)
-        } else {
-            saveEventToLocalDataStore(setUserIdLogEvent)
-        }
+        saveEventToDataStore(setUserIdLogEvent)
         
         let validID = setGenericUserID(type: .userID, genericUserID: userId, userGenerated: userGenerated)
         
@@ -148,13 +139,8 @@ public extension NeuroID {
     static func setRegisteredUserID(_ registeredUserID: String) -> Bool {
 //        Save log event
         let setRegisteredUserIdLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Set Registered User Id Attempt: \(scrubIdentifier(identifier: registeredUserID))")
-        
-        if !NeuroID.isSDKStarted {
-            saveQueuedEventToLocalDataStore(setRegisteredUserIdLogEvent)
-        } else {
-            saveEventToLocalDataStore(setRegisteredUserIdLogEvent)
-        }
-        
+        saveEventToDataStore(setRegisteredUserIdLogEvent)
+       
         if !NeuroID.registeredUserID.isEmpty, registeredUserID != NeuroID.registeredUserID {
             NeuroID.saveEventToLocalDataStore(NIDEvent(level: "warn", m: "Multiple Registered User Id Attempts : \(scrubIdentifier(identifier: registeredUserID))"))
             NIDLog.e("Multiple Registered UserID Attempt: Only 1 Registered UserID can be set per session")
@@ -177,23 +163,13 @@ public extension NeuroID {
      */
     static func attemptedLogin(_ attemptedRegisteredUserId: String? = nil) -> Bool {
 //        Save log event
-        let scrubbedId = (attemptedRegisteredUserId != nil) ? scrubIdentifier(identifier: attemptedRegisteredUserId!) : "null"
-        let attemptedLoginAttemptLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "attempted login with attemptedRegisteredUserId: \(scrubbedId)")
-        if !NeuroID.isSDKStarted {
-            saveQueuedEventToLocalDataStore(attemptedLoginAttemptLogEvent)
-        } else {
-            saveEventToLocalDataStore(attemptedLoginAttemptLogEvent)
-        }
-        
-//
+        let attemptedLoginAttemptLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "attempted login with attemptedRegisteredUserId: \(scrubIdentifier(identifier: attemptedRegisteredUserId ?? "null"))")
+        saveEventToDataStore(attemptedLoginAttemptLogEvent)
+
         let captured = setGenericUserID(type: .attemptedLogin, genericUserID: attemptedRegisteredUserId ?? "scrubbed-id-failed-validation", userGenerated: attemptedRegisteredUserId != nil)
         
         if !captured {
-            if !NeuroID.isSDKStarted {
-                saveQueuedEventToLocalDataStore(NIDEvent(uid: "scrubbed-id-failed-validation"))
-            } else {
-                saveEventToLocalDataStore(NIDEvent(uid: "scrubbed-id-failed-validation"))
-            }
+            saveEventToDataStore(NIDEvent(uid: "scrubbed-id-failed-validation"))
         }
         return true
     }

--- a/NeuroID/NeuroIDClass/Extensions/NIDUser.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDUser.swift
@@ -115,7 +115,7 @@ public extension NeuroID {
     
     internal static func setUserID(_ userId: String, _ userGenerated: Bool) -> Bool {
 //        Save log event
-        let setUserIdLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Set User Id Attempt: \(scrubIdentifier(identifier: userId))")
+        let setUserIdLogEvent = NIDEvent(type: NIDEventName.log, level: "INFO", m: "Set User Id Attempt: \(scrubIdentifier(identifier: userId))")
         saveEventToDataStore(setUserIdLogEvent)
         
         let validID = setGenericUserID(type: .userID, genericUserID: userId, userGenerated: userGenerated)
@@ -138,7 +138,7 @@ public extension NeuroID {
     
     static func setRegisteredUserID(_ registeredUserID: String) -> Bool {
 //        Save log event
-        let setRegisteredUserIdLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "Set Registered User Id Attempt: \(scrubIdentifier(identifier: registeredUserID))")
+        let setRegisteredUserIdLogEvent = NIDEvent(type: NIDEventName.log, level: "INFO", m: "Set Registered User Id Attempt: \(scrubIdentifier(identifier: registeredUserID))")
         saveEventToDataStore(setRegisteredUserIdLogEvent)
        
         if !NeuroID.registeredUserID.isEmpty, registeredUserID != NeuroID.registeredUserID {
@@ -163,7 +163,7 @@ public extension NeuroID {
      */
     static func attemptedLogin(_ attemptedRegisteredUserId: String? = nil) -> Bool {
 //        Save log event
-        let attemptedLoginAttemptLogEvent = NIDEvent(type: NIDEventName.log, level: "info", m: "attempted login with attemptedRegisteredUserId: \(scrubIdentifier(identifier: attemptedRegisteredUserId ?? "null"))")
+        let attemptedLoginAttemptLogEvent = NIDEvent(type: NIDEventName.log, level: "INFO", m: "attempted login with attemptedRegisteredUserId: \(scrubIdentifier(identifier: attemptedRegisteredUserId ?? "null"))")
         saveEventToDataStore(attemptedLoginAttemptLogEvent)
 
         let captured = setGenericUserID(type: .attemptedLogin, genericUserID: attemptedRegisteredUserId ?? "scrubbed-id-failed-validation", userGenerated: attemptedRegisteredUserId != nil)

--- a/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/NeuroID/NeuroIDClass/NeuroID.swift
@@ -98,6 +98,7 @@ public class NeuroID: NSObject {
 
         if !validateClientKey(clientKey) {
             NIDLog.e("Invalid Client Key")
+            saveQueuedEventToLocalDataStore(NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Invalid Client Key \(clientKey)"))
             return false
         }
 

--- a/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/NeuroID/NeuroIDClass/NeuroID.swift
@@ -118,6 +118,7 @@ public class NeuroID: NSObject {
 
         // Reset tab id / packet number on configure
         setUserDefaultKey(Constants.storageTabIDKey.rawValue, value: nil)
+        saveEventToDataStore(NIDEvent(type: NIDEventName.log, level: "info", m: "Reset Tab Id"))
         packetNumber = 0
 
         networkMonitor = NetworkMonitoringService()
@@ -142,11 +143,7 @@ public class NeuroID: NSObject {
         } catch {
             NIDLog.e("Failed to Stop because \(error)")
             let stopFailedLogEvent = NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Failed to Stop because \(error)")
-            if !NeuroID.isSDKStarted {
-                saveQueuedEventToLocalDataStore(stopFailedLogEvent)
-            } else {
-                saveEventToLocalDataStore(stopFailedLogEvent)
-            }
+           saveEventToDataStore(stopFailedLogEvent)
             return false
         }
 

--- a/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/NeuroID/NeuroIDClass/NeuroID.swift
@@ -139,6 +139,12 @@ public class NeuroID: NSObject {
             _ = try closeSession(skipStop: true)
         } catch {
             NIDLog.e("Failed to Stop because \(error)")
+            let stopFailedLogEvent = NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Failed to Stop because \(error)")
+            if !NeuroID.isSDKStarted {
+                saveQueuedEventToLocalDataStore(stopFailedLogEvent)
+            } else {
+                saveEventToLocalDataStore(stopFailedLogEvent)
+            }
             return false
         }
 

--- a/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/NeuroID/NeuroIDClass/NeuroID.swift
@@ -118,7 +118,7 @@ public class NeuroID: NSObject {
 
         // Reset tab id / packet number on configure
         setUserDefaultKey(Constants.storageTabIDKey.rawValue, value: nil)
-        saveEventToDataStore(NIDEvent(type: NIDEventName.log, level: "info", m: "Reset Tab Id"))
+        saveEventToDataStore(NIDEvent(type: NIDEventName.log, level: "INFO", m: "Reset Tab Id"))
         packetNumber = 0
 
         networkMonitor = NetworkMonitoringService()

--- a/NeuroID/Utilities/NIDConfigService.swift
+++ b/NeuroID/Utilities/NIDConfigService.swift
@@ -51,11 +51,7 @@ class NIDConfigService: ConfigServiceProtocol {
                 self.configCache = ConfigResponseData()
                 self.cacheSetWithRemote = false
                 let failedRetrievalConfig = NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Failed to retrieve NID config: \(error). Default values will be used.")
-                if !NeuroID.isSDKStarted {
-                    NeuroID.saveQueuedEventToLocalDataStore(failedRetrievalConfig)
-                } else {
-                    NeuroID.saveEventToLocalDataStore(failedRetrievalConfig)
-                }
+                NeuroID.saveEventToDataStore(failedRetrievalConfig)
                 completion()
             }
         }

--- a/NeuroID/Utilities/NIDConfigService.swift
+++ b/NeuroID/Utilities/NIDConfigService.swift
@@ -50,6 +50,12 @@ class NIDConfigService: ConfigServiceProtocol {
                 NIDLog.e("Failed to retrieve NID Config \(error)")
                 self.configCache = ConfigResponseData()
                 self.cacheSetWithRemote = false
+                let failedRetrievalConfig = NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Failed to retrieve NID config: \(error). Default values will be used.")
+                if !NeuroID.isSDKStarted {
+                    NeuroID.saveQueuedEventToLocalDataStore(failedRetrievalConfig)
+                } else {
+                    NeuroID.saveEventToLocalDataStore(failedRetrievalConfig)
+                }
                 completion()
             }
         }

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -114,7 +114,7 @@ class NeuroIDClassTests: XCTestCase {
 
         assertStoredEventCount(type: "CREATE_SESSION", count: 0)
 
-        assertStoredEventTypeAndCount(type: "LOG", count: 2, queued: true)
+        assertStoredEventTypeAndCount(type: "LOG", count: 1, queued: true)
 
         assert(NeuroID.environment == "\(Constants.environmentTest.rawValue)")
     }
@@ -169,7 +169,7 @@ class NeuroIDClassTests: XCTestCase {
             // post action test
             assert(started)
             assert(NeuroID.isSDKStarted)
-            assert(DataStore.events.count == 12)
+            assert(DataStore.events.count == 13)
 
             self.assertStoredEventCount(type: "CREATE_SESSION", count: 1)
             self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 1)

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -114,7 +114,7 @@ class NeuroIDClassTests: XCTestCase {
 
         assertStoredEventCount(type: "CREATE_SESSION", count: 0)
 
-        assertStoredEventTypeAndCount(type: "LOG", count: 1, queued: true)
+        assertStoredEventTypeAndCount(type: "LOG", count: 2, queued: true)
 
         assert(NeuroID.environment == "\(Constants.environmentTest.rawValue)")
     }
@@ -587,7 +587,7 @@ class NIDNewSessionTests: XCTestCase {
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: true)
-        assertQueuedEventTypeAndCount(type: "LOG", count: 3)
+        assertQueuedEventTypeAndCount(type: "LOG", count: 4)
     }
 
     func test_pauseCollection() {
@@ -1070,7 +1070,6 @@ class NIDUserTests: XCTestCase {
         assert(fnSuccess == true)
         assert(NeuroID.userID == expectedValue)
         assert(storedValue == nil)
-
         assert(DataStore.events.count == 0)
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -157,9 +157,7 @@ class NeuroIDClassTests: XCTestCase {
     func test_start_success_queuedEvent() {
         _ = NeuroID.stop()
         let setUserIDRes = NeuroID.setUserID("test_uid")
-
         assert(setUserIDRes)
-        assertStoredEventTypeAndCount(type: "LOG", count: 1, queued: true)
         NeuroID._isSDKStarted = false
 
         // pre tests
@@ -171,12 +169,12 @@ class NeuroIDClassTests: XCTestCase {
             // post action test
             assert(started)
             assert(NeuroID.isSDKStarted)
-
             assert(DataStore.events.count == 8)
             self.assertStoredEventCount(type: "CREATE_SESSION", count: 1)
             self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 1)
             self.assertStoredEventCount(type: "SET_USER_ID", count: 1)
             self.assertStoredEventCount(type: "SET_VARIABLE", count: 4)
+            self.assertStoredEventCount(type: "LOG", count: 1)
         }
     }
 

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -902,7 +902,7 @@ class NIDUserTests: XCTestCase {
 
     func test_scrubEmailId() {
         let id = "tt@test.com"
-        let expectedId = "**@test.com"
+        let expectedId = "t*@test.com"
         let scrubbedId = NeuroID.scrubIdentifier(identifier: id)
         XCTAssertEqual(scrubbedId, expectedId)
     }

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -169,14 +169,14 @@ class NeuroIDClassTests: XCTestCase {
             // post action test
             assert(started)
             assert(NeuroID.isSDKStarted)
-            assert(DataStore.events.count == 13)
+            assert(DataStore.events.count == 14)
 
             self.assertStoredEventCount(type: "CREATE_SESSION", count: 1)
             self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 1)
             self.assertStoredEventCount(type: "SET_USER_ID", count: 1)
             self.assertStoredEventCount(type: "APPLICATION_METADATA", count: 1)
             self.assertStoredEventCount(type: "SET_VARIABLE", count: 4)
-            self.assertStoredEventCount(type: "LOG", count: 5)
+            self.assertStoredEventCount(type: "LOG", count: 6)
         }
     }
 
@@ -539,7 +539,7 @@ class NIDNewSessionTests: XCTestCase {
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
         assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
-        assertStoredEventTypeAndCount(type: "LOG", count: 2)
+        assertStoredEventTypeAndCount(type: "LOG", count: 3)
     }
 
     func test_startSession_success_no_id() {
@@ -603,7 +603,7 @@ class NIDNewSessionTests: XCTestCase {
         assertQueuedEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
         assertQueuedEventTypeAndCount(type: "SET_VARIABLE", count: 4)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: true)
-        assertQueuedEventTypeAndCount(type: "LOG", count: 4)
+        assertQueuedEventTypeAndCount(type: "LOG", count: 5)
     }
 
     func test_pauseCollection() {

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -169,12 +169,12 @@ class NeuroIDClassTests: XCTestCase {
             // post action test
             assert(started)
             assert(NeuroID.isSDKStarted)
-            assert(DataStore.events.count == 8)
+            assert(DataStore.events.count == 12)
             self.assertStoredEventCount(type: "CREATE_SESSION", count: 1)
             self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 1)
             self.assertStoredEventCount(type: "SET_USER_ID", count: 1)
             self.assertStoredEventCount(type: "SET_VARIABLE", count: 4)
-            self.assertStoredEventCount(type: "LOG", count: 1)
+            self.assertStoredEventCount(type: "LOG", count: 5)
         }
     }
 

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -172,7 +172,7 @@ class NeuroIDClassTests: XCTestCase {
             assert(started)
             assert(NeuroID.isSDKStarted)
 
-            assert(DataStore.events.count == 7)
+            assert(DataStore.events.count == 8)
             self.assertStoredEventCount(type: "CREATE_SESSION", count: 1)
             self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 1)
             self.assertStoredEventCount(type: "SET_USER_ID", count: 1)


### PR DESCRIPTION
Add log events for the following events:

- set user id attempt - what was attempted to be set
- set registered user id attempt - what was attempted to be set
- set variable - put value in '' so to know its empty string or nil?
- tab id change/configure attempt or success? -_**(Note-only added tab reset log event and not retrieval. getTabId() is called after events are pulled from datastore and ready to be sent in post())**_
- start app flow log
- start and start session
- close session 
- any NeuroID error message record an internal log event

-Compare with Android [PR](https://github.com/Neuro-ID/neuroid-android-sdk/pull/337) 
