### PR TITLE
ENG-8380-match tabID pattern with android

### DIFF
--- a/NeuroID/NIDParamsCreator.swift
+++ b/NeuroID/NIDParamsCreator.swift
@@ -111,11 +111,11 @@ enum ParamsCreator {
         let tabIdName = Constants.storageTabIDKey.rawValue
         let tid = getUserDefaultKeyString(tabIdName)
 
-        if tid != nil && !tid!.contains("-") {
+        if tid != nil {
             return tid!
         } else {
-            let randString = generateID()
-            let tid = randString.replacingOccurrences(of: "-", with: "").prefix(12)
+//          ENG-8380 - matching tabID with Android
+            let tid = "mobile-" + generateID()
             setUserDefaultKey(tabIdName, value: tid)
             return "\(tid)"
         }

--- a/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/NeuroID/NeuroIDClass/NeuroID.swift
@@ -98,6 +98,7 @@ public class NeuroID: NSObject {
 
         if !validateClientKey(clientKey) {
             NIDLog.e("Invalid Client Key")
+            setUserDefaultKey(Constants.storageTabIDKey.rawValue, value: ParamsCreator.getTabId() + "-invalid-client-key")
             return false
         }
 

--- a/SDKTest/NIDParamsCreatorTests.swift
+++ b/SDKTest/NIDParamsCreatorTests.swift
@@ -277,13 +277,8 @@ class NIDParamsCreatorTests: XCTestCase {
     }
 
     func test_getTabId_random() {
-        let expectedValue = "test-tid"
-
-        UserDefaults.standard.set(expectedValue, forKey: tidKey)
-
         let value = ParamsCreator.getTabId()
-
-        assert(value != expectedValue)
+        assert(value.prefix(11) == "mobile-nid-")
     }
 
     let didKey = Constants.storageDeviceIDKey.rawValue
@@ -312,7 +307,7 @@ class NIDParamsCreatorTests: XCTestCase {
         let expectedValue = 40
 
         let value = ParamsCreator.generateID()
-        
+
         assert(value.count == expectedValue)
         assert(value.hasPrefix("nid-"))
     }


### PR DESCRIPTION
Matching iOS tabID with android eg. mobile-nid-719f902c-7307-4d5f-8157-6d43c88589eb.