### PR TITLE
ENG-8455 removing nid prefix from all generated random id's except for Session ID

### DIFF
--- a/NeuroID/NIDParamsCreator.swift
+++ b/NeuroID/NIDParamsCreator.swift
@@ -135,8 +135,7 @@ enum ParamsCreator {
     }
 
     static func generateID() -> String {
-//        ENG-8301 Add nid prefix for easier debugging
-        return "nid-" + UUID().uuidString
+        return UUID().uuidString
     }
 
     static func getDnt() -> Bool {

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -34,7 +34,7 @@ public extension NeuroID {
         if let sidValue = sid {
             return sidValue
         }
-
+        // ENG-8455 nid prefix to session id for easier debugging
         let id = "nid-" + ParamsCreator.generateID()
         setUserDefaultKey(sidKeyName, value: id)
 

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -35,7 +35,7 @@ public extension NeuroID {
             return sidValue
         }
 
-        let id = ParamsCreator.generateID()
+        let id = "nid-" + ParamsCreator.generateID()
         setUserDefaultKey(sidKeyName, value: id)
 
         NIDLog.i("\(Constants.sessionTag.rawValue) \(id)")

--- a/SDKTest/NIDParamsCreatorTests.swift
+++ b/SDKTest/NIDParamsCreatorTests.swift
@@ -279,7 +279,7 @@ class NIDParamsCreatorTests: XCTestCase {
     func test_getTabId_random() {
         UserDefaults.standard.set(nil, forKey: tidKey)
         let value = ParamsCreator.getTabId()
-        assert(value.prefix(11) == "mobile-nid-")
+        assert(value.prefix(7) == "mobile-")
     }
 
     let didKey = Constants.storageDeviceIDKey.rawValue
@@ -305,12 +305,11 @@ class NIDParamsCreatorTests: XCTestCase {
 
     // Private Access Level
     func test_generateID() {
-        let expectedValue = 40
+        let expectedValue = 36
 
         let value = ParamsCreator.generateID()
 
         assert(value.count == expectedValue)
-        assert(value.hasPrefix("nid-"))
     }
 
     let dntKey = Constants.storageDntKey.rawValue

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -1368,6 +1368,7 @@ class NIDClientSiteIdTests: XCTestCase {
         let value = NeuroID.getClientID()
 
         assert(value != expectedValue)
+        assert(value.prefix(3) != "nid")
     }
 
     func test_getClientKey() {

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -1368,6 +1368,7 @@ class NIDClientSiteIdTests: XCTestCase {
         let value = NeuroID.getClientID()
 
         assert(value != expectedValue)
+        // ENG-8455 nid prefix should only exist for session id
         assert(value.prefix(3) != "nid")
     }
 


### PR DESCRIPTION
Removing `nid-` prefix from random generated id's like ClientID and tabID but keeping it for Session ID.

 SessionId: nid-9EDAB3F8-7BB6-442C-9C59-7CD7D6B76A26
 ClientID: 90D422EA-BD13-41F8-BB7C-A30144CF47FA
 TabID: mobile-1B3037CF-4485-4940-B274-F017EE9D6909
