### PR TITLE
ENG-8385 - Include ADV Lib in SDK to avoid separate repos. Conditional inclusion

### DIFF
--- a/NeuroID.podspec
+++ b/NeuroID.podspec
@@ -31,7 +31,7 @@ end
 s.subspec 'AdvancedDevice' do |advanced|
     advanced.ios.deployment_target = '12.0'
     advanced.source_files = "NeuroID/**/*.{h,c,m,swift,mlmodel,mlmodelc}"
-    advanced.dependency 'NeuroIDAdvancedDevice'
+    advanced.dependency 'FingerprintPro', '~> 2.0'
 end
 
 s.license = { :type => "MIT", :text => <<-LICENSE

--- a/NeuroID/NIDEvent.swift
+++ b/NeuroID/NIDEvent.swift
@@ -91,6 +91,7 @@ public enum NIDEventName: String {
     case cadenceReadingAccel = "CADENCE_READING_ACCEL"
     case networkState = "NETWORK_STATE"
     case applicationMetaData = "APPLICATION_METADATA"
+    case advancedDeviceRequestFailed = "ADVANCED_DEVICE_REQUEST_FAILED"
 
     // Memory and queue events
     case bufferFull = "FULL_BUFFER"

--- a/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
@@ -5,8 +5,8 @@
 //  Created by Kevin Sites on 10/13/23.
 //
 
+import FingerprintPro
 import Foundation
-import NeuroIDAdvancedDevice
 
 public extension NeuroID {
     internal static var deviceSignalService: DeviceSignalService = NeuroIDADV()
@@ -20,12 +20,12 @@ public extension NeuroID {
                 completion(started)
                 return
             }
-                   
+
             checkThenCaptureAdvancedDevice(advancedDeviceSignals)
             completion(started)
         }
     }
-    
+
     static func startSession(
         _ sessionID: String? = nil,
         _ advancedDeviceSignals: Bool,
@@ -36,27 +36,27 @@ public extension NeuroID {
                 completion(sessionRes)
                 return
             }
-                   
+
             checkThenCaptureAdvancedDevice(advancedDeviceSignals)
             completion(sessionRes)
         }
     }
-    
+
     internal static func getCachedADV() -> Bool {
         if let storedADVKey = getUserDefaultKeyDict(Constants.storageAdvancedDeviceKey.rawValue) {
             if let exp = storedADVKey["exp"] as? Double, let requestID = storedADVKey["key"] as? String {
                 let currentTimeEpoch = Date().timeIntervalSince1970
-                
+
                 if currentTimeEpoch < exp {
                     captureADVEvent(requestID, cached: true, latency: 0)
                     return true
                 }
             }
         }
-        
+
         return false
     }
-    
+
     internal static func getNewADV() {
         deviceSignalService.getAdvancedDeviceSignal(
             NeuroID.clientKey ?? "",
@@ -67,7 +67,7 @@ public extension NeuroID {
             case .success((let requestID, let duration)):
 
                 captureADVEvent(requestID, cached: false, latency: duration)
-                    
+
                 setUserDefaultKey(
                     Constants.storageAdvancedDeviceKey.rawValue,
                     value: ["exp": UtilFunctions.getFutureTimeStamp(24),
@@ -77,11 +77,14 @@ public extension NeuroID {
                 NeuroID.saveEventToLocalDataStore(
                     NIDEvent(type: .log, level: "ERROR", m: error.localizedDescription)
                 )
+                NeuroID.saveEventToDataStore(
+                    NIDEvent(type: .advancedDeviceRequestFailed, m: error.localizedDescription)
+                )
                 return
             }
         }
     }
-    
+
     internal static func captureADVEvent(_ requestID: String, cached: Bool, latency: Double) {
         NeuroID.saveEventToLocalDataStore(
             NIDEvent(
@@ -93,12 +96,12 @@ public extension NeuroID {
             )
         )
     }
-    
+
     /**
      Based on the parameter passed in AND the sampling flag, this function will make a call to the ADV library or not,
      Default is to use the global settings from the NeuroID class but can be overridden (see `start`
      or `startSession` in the `NIDAdvancedDevice.swift` file.
-     
+
      Marked as `@objc` because this method can be called with reflection if the ADV library is not installed.
      Because of the reflection we use an array with a boolean instead of just boolean. Log the shouldCapture flag
      in a LOG event (isAdvancedDevice setting: <true/false>.
@@ -108,10 +111,10 @@ public extension NeuroID {
     ) {
         let logEvent = NIDEvent(type: .log, level: "INFO", m: "shouldCapture setting: \(shouldCapture)")
         NeuroID.saveEventToDataStore(logEvent)
-        
+
         // Verify the command is called with a true value (want to capture) AND that the session
         //  is NOT being restricted/throttled prior to calling for an ADV event
-        
+
         if shouldCapture.indices.contains(0),
            shouldCapture[0],
            NeuroID.samplingService.isSessionFlowSampled
@@ -121,5 +124,179 @@ public extension NeuroID {
                 getNewADV()
             }
         }
+    }
+}
+
+// ADV Library
+
+struct NIDADVKeyResponse: Codable {
+    let key: String
+}
+
+protocol DeviceSignalService {
+    func getAdvancedDeviceSignal(_ apiKey: String, clientID: String?, linkedSiteID: String?, completion: @escaping (Result<(String, Double), Error>) -> Void)
+}
+
+class NeuroIDADV: NSObject, DeviceSignalService {
+    public func getAdvancedDeviceSignal(_ apiKey: String, clientID: String?, linkedSiteID: String?, completion: @escaping (Result<(String, Double), Error>) -> Void) {
+        // Retrieve Key from NID Server for Request
+        NeuroIDADV.getAPIKey(apiKey, clientID: clientID, linkedSiteID: linkedSiteID) { result in
+            switch result {
+            case .success(let fAPiKey):
+                // Retrieve ADV Data using Request Key
+                NeuroIDADV.retryAPICall(apiKey: fAPiKey, maxRetries: 3, delay: 2) { result in
+                    switch result {
+                    case .success(let (value, duration)):
+                        completion(.success((value, duration)))
+                    case .failure(let error):
+                        completion(.failure(error))
+                    }
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    static func getAPIKey(
+        _ apiKey: String,
+        clientID: String? = "",
+        linkedSiteID: String? = "",
+        completion: @escaping (Result<String, Error>) -> Void
+    ) {
+        let apiURL = URL(string: "https://receiver.neuroid.cloud/a/\(apiKey)?clientId=\(clientID ?? "")&linkedSiteId=\(linkedSiteID ?? "")")!
+        let task = URLSession.shared.dataTask(with: apiURL) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            if let httpResponse = response as? HTTPURLResponse {
+                if httpResponse.statusCode == 403 {
+                    completion(
+                        .failure(
+                            createError(code: 1, description: "403")
+                        )
+                    )
+                    return
+                }
+
+                if httpResponse.statusCode == 204 {
+                    completion(
+                        .failure(
+                            createError(code: 8, description: "204")
+                        )
+                    )
+                    return
+                }
+            }
+
+            guard let data = data else {
+                completion(
+                    .failure(
+                        createError(code: 2, description: "NeuroID API Error: No Data Received")
+                    )
+                )
+                return
+            }
+
+            do {
+                let decoder = JSONDecoder()
+                let myResponse = try decoder.decode(NIDADVKeyResponse.self, from: data)
+
+                if let data = Data(base64Encoded: myResponse.key) {
+                    if let string = String(data: data, encoding: .utf8) {
+                        completion(.success(string))
+                    } else {
+                        completion(
+                            .failure(
+                                createError(code: 3, description: "NeuroID API Error: Unable to convert to string")
+                            )
+                        )
+                    }
+                } else {
+                    completion(
+                        .failure(
+                            createError(code: 4, description: "NeuroID API Error: Error Retrieving Data")
+                        )
+                    )
+                }
+            } catch {
+                completion(.failure(error))
+            }
+        }
+        task.resume()
+    }
+
+    static func getRequestID(
+        _ apiKey: String,
+        completion: @escaping (Result<String, Error>) -> Void
+    ) {
+        if #available(iOS 12.0, *) {
+            let region: Region = .custom(domain: "https://advanced.neuro-id.com")
+            let configuration = Configuration(apiKey: apiKey, region: region)
+            let client = FingerprintProFactory.getInstance(configuration)
+            client.getVisitorIdResponse { result in
+                switch result {
+                case .success(let fResponse):
+                    completion(.success(fResponse.requestId))
+                case .failure(let error):
+                    completion(
+                        .failure(
+                            createError(code: 6, description: "Fingerprint Response Failure (code 6): \(error.localizedDescription)")
+                        )
+                    )
+                }
+            }
+        } else {
+            completion(
+                .failure(
+                    createError(code: 7, description: "Fingerprint Response Failure (code 7): Method Not Available")
+                )
+            )
+        }
+    }
+
+    static func retryAPICall(
+        apiKey: String,
+        maxRetries: Int,
+        delay: TimeInterval,
+        completion: @escaping (Result<(String, TimeInterval), Error>) -> Void
+    ) {
+        var currentRetry = 0
+
+        func attemptAPICall() {
+            let startTime = Date()
+
+            getRequestID(apiKey) { result in
+                if case .failure(let error) = result {
+                    if error.localizedDescription.contains("Method not available") {
+                        completion(.failure(error))
+                    } else if currentRetry < maxRetries {
+                        currentRetry += 1
+                        DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+                            attemptAPICall()
+                        }
+                    } else {
+                        completion(.failure(error))
+                    }
+                } else if case .success(let value) = result {
+                    let duration = Date().timeIntervalSince(startTime) * 1000
+                    completion(.success((value, duration)))
+                }
+            }
+        }
+
+        attemptAPICall()
+    }
+
+    static func createError(code: Int, description: String) -> NSError {
+        return NSError(
+            domain: "NeuroIDAdvancedDevice",
+            code: code,
+            userInfo: [
+                NSLocalizedDescriptionKey: description,
+            ]
+        )
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -8,8 +8,7 @@ target 'NeuroID' do
   use_frameworks!
 
 
-  pod 'NeuroIDAdvancedDevice'
-
+  pod 'FingerprintPro', '~> 2.0'
   pod 'Alamofire'
 end
 target 'SDKTest' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,14 +3,12 @@ PODS:
   - DSJSONSchemaValidation (2.0.7)
   - FingerprintPro (2.2.0)
   - JSONSchema (0.5.0)
-  - NeuroIDAdvancedDevice (1.0.2):
-    - FingerprintPro (~> 2.0)
 
 DEPENDENCIES:
   - Alamofire
   - DSJSONSchemaValidation
+  - FingerprintPro (~> 2.0)
   - JSONSchema (= 0.5.0)
-  - NeuroIDAdvancedDevice
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -18,15 +16,13 @@ SPEC REPOS:
     - DSJSONSchemaValidation
     - FingerprintPro
     - JSONSchema
-    - NeuroIDAdvancedDevice
 
 SPEC CHECKSUMS:
   Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
   DSJSONSchemaValidation: 46e30ccfa9908c49d184f453d556f55aa0aac1ff
   FingerprintPro: 72e35dc0315b75ba36eafaaed996dbb2f35f7326
   JSONSchema: 52453ed2f570370b5e3ccd1c943afdfa5ea70db5
-  NeuroIDAdvancedDevice: 8c3da2679da4eca7cb499e111f7e725977be66bd
 
-PODFILE CHECKSUM: 090790257a48acef9caa8a475c7fb3aa58f17f20
+PODFILE CHECKSUM: a6021a0dd79d8afb4baad3a618159a033552121e
 
 COCOAPODS: 1.14.3

--- a/SDKTest/MultiAppFlowTests.swift
+++ b/SDKTest/MultiAppFlowTests.swift
@@ -6,7 +6,6 @@
 //
 
 @testable import NeuroID
-@testable import NeuroIDAdvancedDevice
 import XCTest
 
 final class MultiAppFlowTests: XCTestCase {

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -6,7 +6,6 @@
 //
 
 @testable import NeuroID
-@testable import NeuroIDAdvancedDevice
 import XCTest
 
 class NeuroIDClassTests: XCTestCase {

--- a/SDKTest/Utils/MockDeviceSignalService.swift
+++ b/SDKTest/Utils/MockDeviceSignalService.swift
@@ -6,14 +6,9 @@
 
 import Foundation
 @testable import NeuroID
-import NeuroIDAdvancedDevice
 
 class MockDeviceSignalService: DeviceSignalService {
     var mockResult: Result<(String, Double), Error>?
-
-    func getAdvancedDeviceSignal(_ apiKey: String, completion: @escaping (Result<(String, Double), Error>) -> Void) {
-        getAdvancedDeviceSignal(apiKey, clientID: "", linkedSiteID: "", completion: completion)
-    }
 
     func getAdvancedDeviceSignal(_ apiKey: String, clientID: String?, linkedSiteID: String?, completion: @escaping (Result<(String, Double), Error>) -> Void) {
         if let result = mockResult {


### PR DESCRIPTION
Rather than maintain two repos (NeuroID SDK and the [NeuroID ADV Library](https://github.com/Neuro-ID/neuroid-ios-advanced-device-sdk)), this allows all the code to be in one spot and conditionally included depending on the pods package chosen (NeuroID and NeuroID/AdvancedDevice). This aligns us with the Android approach of having different build versions and code included based on that version. Following this PR and Release the [NeuroID ADV Library](https://github.com/Neuro-ID/neuroid-ios-advanced-device-sdk) will be deprecated