### PR TITLE
ENG-9192 - Combine ADV Library into Core

### DIFF
--- a/NeuroID.podspec
+++ b/NeuroID.podspec
@@ -16,30 +16,22 @@ s.source = { :git => "https://github.com/Neuro-ID/neuroid-ios-sdk.git", :tag => 
 s.source_files = "NeuroID/**/*.{h,c,m,swift,mlmodel,mlmodelc}"
 
 s.exclude_files = [
-    'NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift',
     'NeuroID/Utilities/IntegrationHealth.swift'
 ]
 
 s.dependency 'Alamofire'
+s.dependency 'FingerprintPro', '2.7.0'
 
 s.default_subspecs = 'Core'
 s.subspec 'Core' do |core|
     core.source_files = "NeuroID/**/*.{h,c,m,swift,mlmodel,mlmodelc}"
     core.exclude_files = [
-        'NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift', 
         'NeuroID/Utilities/IntegrationHealth.swift'
     ]
 
     core.resource_bundles = {
         'NeuroID' => ['NeuroID/PrivacyInfo.xcprivacy', "Info.plist"]
     }
-end
-
-s.subspec 'AdvancedDevice' do |advanced|
-    advanced.source_files = ['NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift']
-    
-    advanced.dependency 'FingerprintPro', '2.7.0'
-    advanced.dependency "#{s.name}/Core"
 end
 
 s.subspec 'Debug' do |debug|

--- a/NeuroID/NIDParamsCreator.swift
+++ b/NeuroID/NIDParamsCreator.swift
@@ -184,7 +184,7 @@ enum ParamsCreator {
         if let bundleURL = Bundle(for: NeuroIDTracker.self).url(forResource: "NeuroID", withExtension: "bundle") {
             version = Bundle(url: bundleURL)?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         }
-        return "5.ios\(NeuroID.isRN ? "-rn" : "")\(NeuroID.isAdvancedDeviceLib ? "-adv" : "")-\(version ?? "?")"
+        return "5.ios\(NeuroID.isRN ? "-rn" : "")-adv-\(version ?? "?")"
     }
 
     static func getCommandQueueNamespace() -> String {

--- a/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -121,7 +121,7 @@ public extension NeuroID {
                 saveEventToLocalDataStore(createNIDSessionEvent())
                 captureMobileMetadata()
 
-                checkThenCaptureAdvancedDevice()
+                captureAdvancedDevice()
 
                 NeuroID.addLinkedSiteID(siteID)
                 completion(
@@ -274,7 +274,7 @@ extension NeuroID {
             DataStore.insertEvent(screen: "", event: event)
         }
 
-        checkThenCaptureAdvancedDevice()
+        captureAdvancedDevice()
 
         completion()
     }

--- a/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/NeuroID/NeuroIDClass/NeuroID.swift
@@ -76,8 +76,6 @@ public class NeuroID: NSObject {
 
     static var packetNumber: Int32 = 0
 
-    static var isAdvancedDeviceLib = false
-
     // MARK: - Setup
 
     static func verifyClientKeyExists() -> Bool {
@@ -113,8 +111,6 @@ public class NeuroID: NSObject {
 
             return false
         }
-
-        updateBuildTypeFlag()
 
         NeuroID.isAdvancedDevice = isAdvancedDevice
 
@@ -191,28 +187,10 @@ public class NeuroID: NSObject {
         return _isSDKStarted != true
     }
 
-    static func checkThenCaptureAdvancedDevice(_ shouldCapture: Bool = NeuroID.isAdvancedDevice) {
-        let result = checkBuildType("captureAdvancedDevice:")
-        if result.0 {
-            NeuroID.perform(result.1, with: [shouldCapture])
-        } else {
-            NIDLog.d("No Advanced Module found")
-        }
-    }
-
-    static func updateBuildTypeFlag() {
-        let result = checkBuildType("captureAdvancedDevice:")
-        if result.0 {
-            isAdvancedDeviceLib = true
-        } else {
-            isAdvancedDeviceLib = false
-        }
-    }
-
     /**
-     check for existance of the advanced lib method captureAdvancedDevice()
+     check for existance of the a method in an additional package that may or may not be included
      */
-    static func checkBuildType(_ selectorString:String = "captureAdvancedDevice:") -> (Bool, Selector) {
+    static func checkBuildType(_ selectorString:String) -> (Bool, Selector) {
         let selector = NSSelectorFromString(selectorString)
         if NeuroID.responds(to: selector) {
             return (true, selector)

--- a/SDKTest/MultiAppFlowTests.swift
+++ b/SDKTest/MultiAppFlowTests.swift
@@ -104,7 +104,7 @@ final class MultiAppFlowTests: XCTestCase {
         service._isSessionFlowSampled = false
         NeuroID.samplingService = service // setting to false indicating we are throttling
 
-        NeuroID.captureAdvancedDevice([true]) // passing true to indicate we should capture
+        NeuroID.captureAdvancedDevice(true) // passing true to indicate we should capture
 
         let validEvent = DataStore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
         assert(validEvent.count == 0)
@@ -122,7 +122,7 @@ final class MultiAppFlowTests: XCTestCase {
         service._isSessionFlowSampled = true // setting to true indicating we are NOT throttling
         NeuroID.samplingService = service
 
-        NeuroID.captureAdvancedDevice([true]) // passing true to indicate we should capture
+        NeuroID.captureAdvancedDevice(true) // passing true to indicate we should capture
 
         let validEvent = DataStore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
         assert(validEvent.count == 1)

--- a/SDKTest/NIDParamsCreatorTests.swift
+++ b/SDKTest/NIDParamsCreatorTests.swift
@@ -383,25 +383,22 @@ class NIDParamsCreatorTests: XCTestCase {
 
     func test_getSDKVersion() {
         NeuroID.isRN = false
-        NeuroID.isAdvancedDeviceLib = false
         let version = Bundle(for: NeuroIDTracker.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-        let expectedValue = "5.ios-\(version ?? "?")"
+        let expectedValue = "5.ios-adv-\(version ?? "?")"
 
         let value = ParamsCreator.getSDKVersion()
 
         assert(value == expectedValue)
         
         NeuroID.isRN = true
-        NeuroID.isAdvancedDeviceLib = false
         let versionRN = Bundle(for: NeuroIDTracker.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-        let expectedValueRN = "5.ios-rn-\(version ?? "?")"
+        let expectedValueRN = "5.ios-rn-adv-\(version ?? "?")"
 
         let valueRN = ParamsCreator.getSDKVersion()
 
         assert(valueRN == expectedValueRN)
         
         NeuroID.isRN = false
-        NeuroID.isAdvancedDeviceLib = true
         let versionADV = Bundle(for: NeuroIDTracker.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         let expectedValueADV = "5.ios-adv-\(version ?? "?")"
 
@@ -410,7 +407,6 @@ class NIDParamsCreatorTests: XCTestCase {
         assert(valueADV == expectedValueADV)
         
         NeuroID.isRN = true
-        NeuroID.isAdvancedDeviceLib = true
         let versionADVRN = Bundle(for: NeuroIDTracker.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         let expectedValueADVRN = "5.ios-rn-adv-\(version ?? "?")"
 

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -197,13 +197,8 @@ class NeuroIDClassTests: XCTestCase {
 
         assert(value == expectedValue)
 
-        NeuroID.isAdvancedDeviceLib = true
         let resultAdvTrue = NeuroID.getSDKVersion()
         assert(resultAdvTrue.contains("-adv"))
-
-        NeuroID.isAdvancedDeviceLib = false
-        let resultAdvFalse = NeuroID.getSDKVersion()
-        assert(!resultAdvFalse.contains("-adv"))
 
         NeuroID.isRN = true
         let resultRNTrue = NeuroID.getSDKVersion()


### PR DESCRIPTION
This will by default include all our AdvancedDevice functionality into our main SDK package instead of requiring a second library installation. The functionality can be used or ignored with the `isAdvancedDevice: Bool` parameter in the `configure` method. Additionally there are backend security checks for the given `clientKey` when an advanced device request is made to prevent unauthorized access.