### PR TITLE
ENG-9249 - Datastore class refactor

### DIFF
--- a/NeuroID.xcodeproj/project.pbxproj
+++ b/NeuroID.xcodeproj/project.pbxproj
@@ -97,6 +97,9 @@
 		FFAC96C22D358B3D004C2A25 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 6F467EDE2BAA0D8500B0605D /* PrivacyInfo.xcprivacy */; };
 		FFAC96C42D36D7EE004C2A25 /* IdentifierService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAC96C32D36D7EE004C2A25 /* IdentifierService.swift */; };
 		FFAC96C62D36DFF4004C2A25 /* IdentifierServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAC96C52D36DFF4004C2A25 /* IdentifierServiceTests.swift */; };
+		FFAC97A12D40047B004C2A25 /* NIDDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAC97A02D40047B004C2A25 /* NIDDataStore.swift */; };
+		FFAC97A32D401559004C2A25 /* BaseTestClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAC97A22D401559004C2A25 /* BaseTestClass.swift */; };
+		FFAC97A52D4019E5004C2A25 /* NIDDataExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAC97A42D4019E5004C2A25 /* NIDDataExtensionTests.swift */; };
 		FFD6967F2D28988E003928EF /* LocationManagerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD6967E2D28988B003928EF /* LocationManagerService.swift */; };
 /* End PBXBuildFile section */
 
@@ -222,6 +225,9 @@
 		FFAC96C02D358ACC004C2A25 /* UIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButton.swift; sourceTree = "<group>"; };
 		FFAC96C32D36D7EE004C2A25 /* IdentifierService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierService.swift; sourceTree = "<group>"; };
 		FFAC96C52D36DFF4004C2A25 /* IdentifierServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierServiceTests.swift; sourceTree = "<group>"; };
+		FFAC97A02D40047B004C2A25 /* NIDDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIDDataStore.swift; sourceTree = "<group>"; };
+		FFAC97A22D401559004C2A25 /* BaseTestClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTestClass.swift; sourceTree = "<group>"; };
+		FFAC97A42D4019E5004C2A25 /* NIDDataExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIDDataExtensionTests.swift; sourceTree = "<group>"; };
 		FFD6967E2D28988B003928EF /* LocationManagerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManagerService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -329,6 +335,7 @@
 			children = (
 				6F47B9B22B7E81230047DFCB /* Utils */,
 				6FB5672C2B7A7B71009B2959 /* NIDPerformanceTests.swift */,
+				FFAC97A42D4019E5004C2A25 /* NIDDataExtensionTests.swift */,
 				6FF06B26271FCA8300F6704C /* DataStoreTests.swift */,
 				6F39E8CB26CEA9A800BE9834 /* SessionTests.swift */,
 				6F39E8CD26CEA9A800BE9834 /* Info.plist */,
@@ -347,6 +354,7 @@
 				6F935FA82BEE945C00573EE9 /* MultiAppFlowTests.swift */,
 				F24BAE792BF52A0000A3605D /* SampleServiceTests.swift */,
 				FFAC96C52D36DFF4004C2A25 /* IdentifierServiceTests.swift */,
+				FFAC97A22D401559004C2A25 /* BaseTestClass.swift */,
 			);
 			path = SDKTest;
 			sourceTree = "<group>";
@@ -457,6 +465,7 @@
 			children = (
 				F2506FD02AD9A4FB00AD0903 /* NIDAdvancedDevice.swift */,
 				F2AEE7422A27A7B5009690CB /* NIDClientSiteId.swift */,
+				FFAC97A02D40047B004C2A25 /* NIDDataStore.swift */,
 				F2AEE7402A27A719009690CB /* NIDEnv.swift */,
 				F2AEE73A2A27A684009690CB /* NIDForm.swift */,
 				F2420C342BF3A1CD00143928 /* NIDListeners.swift */,
@@ -744,6 +753,7 @@
 				F21702BC29D4CDF900133A1C /* Dictionary.swift in Sources */,
 				1FD6E6BB2C4598DF00C8017E /* NIDPacketNumber.swift in Sources */,
 				F2546A6E2B9A121500348BD7 /* NIDTesting.swift in Sources */,
+				FFAC97A12D40047B004C2A25 /* NIDDataStore.swift in Sources */,
 				F2AEE73B2A27A684009690CB /* NIDForm.swift in Sources */,
 				F23B75542AC36F8A00A7DF4D /* NIDRN.swift in Sources */,
 				F2420C352BF3A1CD00143928 /* NIDListeners.swift in Sources */,
@@ -769,6 +779,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FFAC97A52D4019E5004C2A25 /* NIDDataExtensionTests.swift in Sources */,
 				F21702D629D607E600133A1C /* NIDParamsCreatorTests.swift in Sources */,
 				F216C40A2A72C649001DDABB /* UtilFunctionsTests.swift in Sources */,
 				F27045F02B6A8FBE00FE24FF /* NetworkMonitoringServiceTests.swift in Sources */,
@@ -792,6 +803,7 @@
 				6F935FA92BEE945C00573EE9 /* MultiAppFlowTests.swift in Sources */,
 				6FB5672D2B7A7B71009B2959 /* NIDPerformanceTests.swift in Sources */,
 				FFAC96C62D36DFF4004C2A25 /* IdentifierServiceTests.swift in Sources */,
+				FFAC97A32D401559004C2A25 /* BaseTestClass.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SDKTest/BaseTestClass.swift
+++ b/SDKTest/BaseTestClass.swift
@@ -1,0 +1,86 @@
+//
+//  BaseTestClass.swift
+//  SDKTest
+//
+//  Created by Kevin Sites on 1/21/25.
+//
+
+
+@testable import NeuroID
+import XCTest
+
+class BaseTestClass: XCTestCase {
+    let clientKey = "key_live_vtotrandom_form_mobilesandbox"
+    
+    // Keys for storage:
+    let localStorageNIDStopAll = Constants.storageLocalNIDStopAllKey.rawValue
+    let clientKeyKey = Constants.storageClientKey.rawValue
+    let clientIdKey = Constants.storageClientIDKey.rawValue
+    let tabIdKey = Constants.storageTabIDKey.rawValue
+    
+    func clearOutDataStore() {
+        NeuroID.datastore.removeSentEvents()
+        let _ = NeuroID.datastore.getAndRemoveAllEvents()
+        let _ = NeuroID.datastore.getAndRemoveAllQueuedEvents()
+    }
+    
+    override func setUpWithError() throws {
+        _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
+    }
+    
+    override func setUp() {
+        UserDefaults.standard.removeObject(forKey: Constants.storageAdvancedDeviceKey.rawValue)
+    }
+    
+    override func tearDown() {
+        _ = NeuroID.stop()
+        
+        // Clear out the DataStore Events after each test
+        clearOutDataStore()
+    }
+    
+    func assertDataStoreCount(count: Int) {
+        let allEvents = NeuroID.datastore.getAllEvents()
+        assert(allEvents.count == count)
+    }
+    
+    func assertStoredEventCount(type: String, count: Int) {
+        let allEvents = NeuroID.datastore.getAllEvents()
+        let validEvent = allEvents.filter { $0.type == type }
+
+        assert(validEvent.count == count)
+    }
+
+    func assertStoredEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
+        let allEvents = NeuroID.datastore.getAllEvents()
+        let validEvent = allEvents.filter { $0.type == type }
+
+        assert(validEvent.count == count)
+        if !skipType! {
+            assert(validEvent[0].type == type)
+        }
+    }
+
+    func assertQueuedEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
+        let allEvents = NeuroID.datastore.queuedEvents
+        let validEvent = allEvents.filter { $0.type == type }
+
+        assert(validEvent.count == count)
+        if !skipType! {
+            assert(validEvent[0].type == type)
+        }
+    }
+    
+    func assertDatastoreEventOrigin(type: String, origin: String, originCode: String, queued: Bool) {
+        let allEvents = queued ? NeuroID.datastore.queuedEvents : NeuroID.datastore.getAllEvents()
+        let validEvents = allEvents.filter { $0.type == type }
+
+        let originEvent = validEvents.filter { $0.key == "sessionIdSource" }
+        assert(originEvent.count == 1)
+        assert(originEvent[0].v == origin)
+
+        let originCodeEvent = validEvents.filter { $0.key == "sessionIdCode" }
+        assert(originCodeEvent.count == 1)
+        assert(originCodeEvent[0].v == originCode)
+    }
+}

--- a/SDKTest/ConfigServiceTests.swift
+++ b/SDKTest/ConfigServiceTests.swift
@@ -16,7 +16,7 @@ class ConfigServiceTests: XCTestCase {
     }
     
     func clearOutDataStore() {
-        DataStore.removeSentEvents()
+        NeuroID.datastore.removeSentEvents()
     }
     
     func setupKeyAndMockInternet() {

--- a/SDKTest/DataStoreTests.swift
+++ b/SDKTest/DataStoreTests.swift
@@ -21,14 +21,16 @@ class DataStoreTests: XCTestCase {
     )
 
     let excludeId = "exclude_test_id"
+    
+    var dataStore = DataStore()
 
     override func setUpWithError() throws {
         UserDefaults.standard.setValue(nil, forKey: eventsKey)
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
         _ = NeuroID.stop()
         NeuroID._isSDKStarted = true
-        let _ = DataStore.getAndRemoveAllEvents()
-        let _ = DataStore.getAndRemoveAllQueuedEvents()
+        
+        dataStore = DataStore()
     }
 
     override func tearDownWithError() throws {
@@ -58,132 +60,59 @@ class DataStoreTests: XCTestCase {
         }
     }
 
-    func test_insertEvent_stoppedSDK() {
-        _ = NeuroID.stop()
-
-        DataStore.insertEvent(screen: screenName, event: nidEvent)
-        assert(DataStore.events.count == 0)
-    }
-
-    func test_insertEvent_success() {
-        let screen = "DS_TEST_SCREEN"
-        NeuroID.currentScreenName = screen
-
-        let nidE = nidEvent
-        assert(nidE.url == nil)
-
-        DataStore.insertEvent(screen: screenName, event: nidE)
-        assert(DataStore.events.count == 1)
-        assert(DataStore.events[0].url == "ios://\(screen)")
-    }
-
-    func test_insertQueuedEvent_success() {
-        let screen = "DS_TEST_SCREEN"
-        NeuroID.currentScreenName = screen
-
-        let nidE = nidEvent
-        assert(nidE.url == nil)
-
-        DataStore.insertQueuedEvent(screen: screenName, event: nidE)
-        assert(DataStore.events.count == 0)
-        assert(DataStore.queuedEvents.count == 1)
-        assert(DataStore.queuedEvents[0].url == "ios://\(screen)")
-    }
-
-    func test_cleanAndStoreEvent_RNScreen() {
-        let nidE = nidEvent
-        nidE.url = "RNScreensNavigationController"
-
-        DataStore.cleanAndStoreEvent(screen: screenName, event: nidE, storeType: "")
-        assert(DataStore.events.count == 0)
-    }
-
-    func test_cleanAndStoreEvent_excludedView_tg() {
-        NeuroID.excludeViewByTestID(excludedView: excludeId)
-
-        let nidE = nidEvent
-        nidE.tg = [
-            "tgs": TargetValue.string(excludeId)
-        ]
-
-        DataStore.cleanAndStoreEvent(screen: screenName, event: nidE, storeType: "")
-        assert(DataStore.events.count == 0)
-    }
-
-    func test_cleanAndStoreEvent_excludedView_tgs() {
-        NeuroID.excludeViewByTestID(excludedView: excludeId)
-
-        let nidE = nidEvent
-
-        nidE.tgs = excludeId
-
-        DataStore.cleanAndStoreEvent(screen: screenName, event: nidE, storeType: "")
-        assert(DataStore.events.count == 0)
-    }
-
-    func test_cleanAndStoreEvent_excludedView_en() {
-        NeuroID.excludeViewByTestID(excludedView: excludeId)
-
-        let nidE = nidEvent
-
-        nidE.en = excludeId
-
-        DataStore.cleanAndStoreEvent(screen: screenName, event: nidE, storeType: "")
-        assert(DataStore.events.count == 0)
-    }
 
     func test_insertCleanedEvent_queued() {
         let nidE = nidEvent
 
-        DataStore.insertCleanedEvent(event: nidE, storeType: "queue")
-        assert(DataStore.events.count == 0)
-        assert(DataStore.queuedEvents.count == 1)
+        dataStore.insertCleanedEvent(event: nidE, storeType: "queue")
+        assert(dataStore.events.count == 0)
+        assert(dataStore.queuedEvents.count == 1)
     }
 
     func test_insertCleanedEvent_event() {
         let nidE = nidEvent
 
-        DataStore.insertCleanedEvent(event: nidE, storeType: "event")
-        assert(DataStore.events.count == 1)
-        assert(DataStore.queuedEvents.count == 0)
+        dataStore.insertCleanedEvent(event: nidE, storeType: "event")
+        assert(dataStore.events.count == 1)
+        assert(dataStore.queuedEvents.count == 0)
     }
 
     func test_getAllEvents() {
-        assert(DataStore.events.count == 0)
+        assert(dataStore.events.count == 0)
 
-        DataStore.events = [
+        dataStore.events = [
             nidEvent
         ]
 
-        let retrievedEvents = DataStore.getAllEvents()
+        let retrievedEvents = dataStore.getAllEvents()
 
         assert(retrievedEvents.count == 1)
     }
 
     func test_getAndRemoveAllEvents() {
-        assert(DataStore.events.count == 0)
+        assert(dataStore.events.count == 0)
 
-        DataStore.events = [
+        dataStore.events = [
             nidEvent
         ]
 
-        let retrievedEvents = DataStore.getAndRemoveAllEvents()
+        let retrievedEvents = dataStore.getAndRemoveAllEvents()
 
         assert(retrievedEvents.count == 1)
-        assert(DataStore.events.count == 0)
+        assert(dataStore.events.count == 0)
     }
 
     func test_getAndRemoveAllQueuedEvents() {
-        assert(DataStore.queuedEvents.count == 0)
+        assert(dataStore.queuedEvents.count == 0)
 
-        DataStore.queuedEvents = [
+        dataStore.queuedEvents = [
             nidEvent
         ]
 
-        let retrievedEvents = DataStore.getAndRemoveAllQueuedEvents()
+        let retrievedEvents = dataStore.getAndRemoveAllQueuedEvents()
 
         assert(retrievedEvents.count == 1)
-        assert(DataStore.queuedEvents.count == 0)
+        assert(dataStore.queuedEvents.count == 0)
     }
 
     func test_getUserDefaultKeyBool() {

--- a/SDKTest/MultiAppFlowTests.swift
+++ b/SDKTest/MultiAppFlowTests.swift
@@ -20,7 +20,7 @@ final class MultiAppFlowTests: XCTestCase {
     let mockedConfig = MockConfigService()
 
     func clearOutDataStore() {
-        let _ = DataStore.getAndRemoveAllEvents()
+        let _ = NeuroID.datastore.getAndRemoveAllEvents()
     }
 
     override func setUpWithError() throws {}
@@ -43,7 +43,7 @@ final class MultiAppFlowTests: XCTestCase {
         _ = NeuroID.configure(clientKey: clientKey)
         NeuroID.deviceSignalService = mockService
         NeuroID.start(true) { _ in
-            let validEvent = DataStore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
+            let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
 
             assert(!NeuroID.isAdvancedDevice)
             assert(validEvent.count == 1)
@@ -55,7 +55,7 @@ final class MultiAppFlowTests: XCTestCase {
         NeuroID.deviceSignalService = mockService
 
         NeuroID.startSession("fake_user_session") { _ in
-            let validEvent = DataStore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
+            let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
 
             assert(NeuroID.isAdvancedDevice)
             assert(validEvent.count == 1)
@@ -67,7 +67,7 @@ final class MultiAppFlowTests: XCTestCase {
         NeuroID.deviceSignalService = mockService
 
         NeuroID.startAppFlow(siteID: "form_dream102", sessionID: "jakeId") { _ in
-            let validEvent = DataStore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
+            let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
 
             assert(NeuroID.isAdvancedDevice)
             assert(validEvent.count == 1)
@@ -78,7 +78,7 @@ final class MultiAppFlowTests: XCTestCase {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: true)
         NeuroID.deviceSignalService = mockService
         NeuroID.start { _ in
-            let validEvent = DataStore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
+            let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
             assert(NeuroID.isAdvancedDevice)
             assert(validEvent.count == 1)
         }
@@ -89,7 +89,7 @@ final class MultiAppFlowTests: XCTestCase {
         NeuroID.deviceSignalService = mockService
         NeuroID.startSession("fake_user_session", true) { _ in
 
-            let validEvent = DataStore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
+            let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
             XCTAssert(!NeuroID.isAdvancedDevice)
             XCTAssertTrue(validEvent.count == 1)
         }
@@ -106,7 +106,7 @@ final class MultiAppFlowTests: XCTestCase {
 
         NeuroID.captureAdvancedDevice(true) // passing true to indicate we should capture
 
-        let validEvent = DataStore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
+        let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
         assert(validEvent.count == 0)
 
         service._isSessionFlowSampled = true
@@ -124,7 +124,7 @@ final class MultiAppFlowTests: XCTestCase {
 
         NeuroID.captureAdvancedDevice(true) // passing true to indicate we should capture
 
-        let validEvent = DataStore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
+        let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
         assert(validEvent.count == 1)
 
         NeuroID._isSDKStarted = false

--- a/SDKTest/NIDDataExtensionTests.swift
+++ b/SDKTest/NIDDataExtensionTests.swift
@@ -1,0 +1,115 @@
+//
+//  NIDDataExtensionTests.swift
+//  SDKTest
+//
+//  Created by Kevin Sites on 1/21/25.
+//
+
+@testable import NeuroID
+import XCTest
+
+class NIDDataExtensionTests: BaseTestClass {
+    let eventsKey = "test_events_stored"
+    let screenName = "test_screen_name"
+    
+    let nidEvent = NIDEvent(
+        type: .radioChange
+    )
+    
+    let excludeId = "exclude_test_id"
+
+    
+    override func setUpWithError() throws {
+        _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
+    }
+    
+    override func setUp() {
+        UserDefaults.standard.removeObject(forKey: Constants.storageAdvancedDeviceKey.rawValue)
+    }
+    
+    override func tearDown() {
+        _ = NeuroID.stop()
+        
+        // Clear out the DataStore Events after each test
+        clearOutDataStore()
+    }
+    
+    func test_saveEventToLocalDataStore_stoppedSDK() {
+        _ = NeuroID.stop()
+
+        NeuroID.saveEventToLocalDataStore(nidEvent, screen: screenName)
+        assert(NeuroID.datastore.events.count == 0)
+    }
+
+    func test_saveEventToLocalDataStore_success() {
+        let screen = "DS_TEST_SCREEN"
+        NeuroID.currentScreenName = screen
+        
+        NeuroID._isSDKStarted = true
+
+        let nidE = nidEvent
+        assert(nidE.url == nil)
+
+        
+        NeuroID.saveEventToLocalDataStore(nidE, screen: screenName)
+        assert(NeuroID.datastore.events.count == 1)
+        assert(NeuroID.datastore.events[0].url == "ios://\(screen)")
+    }
+
+    func test_saveQueuedEventToLocalDataStore_success() {
+        let screen = "DS_TEST_SCREEN"
+        NeuroID.currentScreenName = screen
+
+        let nidE = nidEvent
+        assert(nidE.url == nil)
+
+        NeuroID.saveQueuedEventToLocalDataStore(nidE, screen: screenName)
+        assert(NeuroID.datastore.events.count == 0)
+        assert(NeuroID.datastore.queuedEvents.count == 1)
+        assert(NeuroID.datastore.queuedEvents[0].url == "ios://\(screen)")
+    }
+
+    func test_cleanAndStoreEvent_RNScreen() {
+        let nidE = nidEvent
+        nidE.url = "RNScreensNavigationController"
+
+        NeuroID.cleanAndStoreEvent(screen: screenName, event: nidE, storeType: "")
+        assert(NeuroID.datastore.events.count == 0)
+    }
+
+    func test_cleanAndStoreEvent_excludedView_tg() {
+        NeuroID.excludeViewByTestID(excludedView: excludeId)
+
+        let nidE = nidEvent
+        nidE.tg = [
+            "tgs": TargetValue.string(excludeId)
+        ]
+
+        NeuroID.cleanAndStoreEvent(screen: screenName, event: nidE, storeType: "")
+        assert(NeuroID.datastore.events.count == 0)
+    }
+
+    func test_cleanAndStoreEvent_excludedView_tgs() {
+        NeuroID.excludeViewByTestID(excludedView: excludeId)
+
+        let nidE = nidEvent
+
+        nidE.tgs = excludeId
+
+        NeuroID.cleanAndStoreEvent(screen: screenName, event: nidE, storeType: "")
+        assert(NeuroID.datastore.events.count == 0)
+    }
+
+    func test_cleanAndStoreEvent_excludedView_en() {
+        NeuroID.excludeViewByTestID(excludedView: excludeId)
+
+        let nidE = nidEvent
+
+        nidE.en = excludeId
+
+        NeuroID.cleanAndStoreEvent(screen: screenName, event: nidE, storeType: "")
+        assert(NeuroID.datastore.events.count == 0)
+    }
+    
+}
+

--- a/SDKTest/NIDEventTests.swift
+++ b/SDKTest/NIDEventTests.swift
@@ -18,7 +18,7 @@ class NIDEventTests: XCTestCase {
     
     override func setUp() {
         // Clear out the DataStore Events after each test
-        DataStore.removeSentEvents()
+        NeuroID.datastore.removeSentEvents()
         NeuroID.currentScreenName = nil
     }
     
@@ -150,7 +150,7 @@ class NIDEventTests: XCTestCase {
         tracker?.captureEvent(event: touch2)
         
         /// Get all events
-        let events = DataStore.getAllEvents()
+        let events = NeuroID.datastore.getAllEvents()
         /// Create http request
         let tabId = ParamsCreator.getTabId()
         

--- a/SDKTest/NIDParamsCreatorTests.swift
+++ b/SDKTest/NIDParamsCreatorTests.swift
@@ -46,7 +46,7 @@ class NIDParamsCreatorTests: XCTestCase {
 
     override func setUp() {
         // Clear out the DataStore Events after each test
-        DataStore.removeSentEvents()
+        NeuroID.datastore.removeSentEvents()
     }
 
     // Util Helper Functions

--- a/SDKTest/NeuroIDTrackerTests.swift
+++ b/SDKTest/NeuroIDTrackerTests.swift
@@ -8,9 +8,8 @@
 @testable import NeuroID
 import XCTest
 
-class NeuroIDTrackerTests: XCTestCase {
-    let clientKey = "key_live_vtotrandom_form_mobilesandbox"
-    let userId = "form_mobilesandbox"
+class NeuroIDTrackerTests: BaseTestClass {
+   let userId = "form_mobilesandbox"
     
     let screenNameValue = "testScreen"
     let guidValue = "\(Constants.attrGuidKey.rawValue)"
@@ -27,7 +26,7 @@ class NeuroIDTrackerTests: XCTestCase {
         _ = NeuroID.stop()
         
         // Clear out the DataStore Events after each test
-        DataStore.removeSentEvents()
+        NeuroID.datastore.removeSentEvents()
     }
     
     func sleep(timeout: Double) {
@@ -46,7 +45,7 @@ class NeuroIDTrackerTests: XCTestCase {
     }
     
     func assertEventTypeCount(type: String, expectedCount: Int) -> [NIDEvent] {
-        let dataStoreEvents = DataStore.getAllEvents()
+        let dataStoreEvents = NeuroID.datastore.getAllEvents()
         let filteredEvents = dataStoreEvents.filter { $0.type == type }
         
         assert(filteredEvents.count == expectedCount)
@@ -63,7 +62,7 @@ class NeuroIDTrackerTests: XCTestCase {
     }
     
     func assertViewNOTRegistered(v: UIView) {
-        let dataStoreEvents = DataStore.getAllEvents()
+        let dataStoreEvents = NeuroID.datastore.getAllEvents()
         let filteredEvent = dataStoreEvents.filter { $0.type == "REGISTER_TARGET" }
         assert(filteredEvent.count == 0)
         
@@ -210,52 +209,52 @@ class NeuroIDTrackerTests: XCTestCase {
         uiControllerBasic.view.addSubview(input)
         
         // subscribe happens in the INIT method
-        let tracker = NeuroIDTracker(
+        let _ = NeuroIDTracker(
             screen: "test",
             controller: uiControllerBasic
         )
         
         // Text Field Notification Tests - observeTextInputEvents()
         // Field Focus
-        let _ = DataStore.getAndRemoveAllEvents()
+        let _ = NeuroID.datastore.getAndRemoveAllEvents()
         NotificationCenter.default.post(name: UITextField.textDidBeginEditingNotification, object: input)
-        var e = DataStore.getAndRemoveAllEvents()
+        var e = NeuroID.datastore.getAndRemoveAllEvents()
         assertEventTypeCountFromArray(type: "REGISTER_TARGET", expectedCount: 1, events: e) // because not registered from view
         assertEventTypeCountFromArray(type: "FOCUS", expectedCount: 1, events: e)
         
         // Field Input
         NotificationCenter.default.post(name: UITextField.textDidChangeNotification, object: input)
-        e = DataStore.getAndRemoveAllEvents()
+        e = NeuroID.datastore.getAndRemoveAllEvents()
         assertEventTypeCountFromArray(type: "INPUT", expectedCount: 1, events: e)
 
         // Field Blur
         NotificationCenter.default.post(name: UITextField.textDidEndEditingNotification, object: input)
-        e = DataStore.getAndRemoveAllEvents()
+        e = NeuroID.datastore.getAndRemoveAllEvents()
         assertEventTypeCountFromArray(type: "BLUR", expectedCount: 1, events: e)
         assertEventTypeCountFromArray(type: "TEXT_CHANGE", expectedCount: 1, events: e)
         
         // App Notification Tests - observeAppEvents()
         NotificationCenter.default.post(name: UIDevice.orientationDidChangeNotification, object: UIDevice.self)
-        e = DataStore.getAndRemoveAllEvents()
+        e = NeuroID.datastore.getAndRemoveAllEvents()
         assertEventTypeCountFromArray(type: "DEVICE_ORIENTATION", expectedCount: 1, events: e)
         assertEventTypeCountFromArray(type: "WINDOW_ORIENTATION_CHANGE", expectedCount: 1, events: e)
         
         // Device Notification Tests - observeRotation()
         if #available(iOS 13.0, *) {
             NotificationCenter.default.post(name: UIScene.didActivateNotification, object: UIScene.self)
-            e = DataStore.getAndRemoveAllEvents()
+            e = NeuroID.datastore.getAndRemoveAllEvents()
             assertEventTypeCountFromArray(type: "WINDOW_FOCUS", expectedCount: 1, events: e)
             
             NotificationCenter.default.post(name: UIScene.willDeactivateNotification, object: UIScene.self)
-            e = DataStore.getAndRemoveAllEvents()
+            e = NeuroID.datastore.getAndRemoveAllEvents()
             assertEventTypeCountFromArray(type: "WINDOW_BLUR", expectedCount: 1, events: e)
         } else {
             NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: UIApplication.self)
-            e = DataStore.getAndRemoveAllEvents()
+            e = NeuroID.datastore.getAndRemoveAllEvents()
             assertEventTypeCountFromArray(type: "WINDOW_FOCUS", expectedCount: 1, events: e)
             
             NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: UIApplication.self)
-            e = DataStore.getAndRemoveAllEvents()
+            e = NeuroID.datastore.getAndRemoveAllEvents()
             assertEventTypeCountFromArray(type: "WINDOW_BLUR", expectedCount: 1, events: e)
         }
     }

--- a/SDKTest/SessionTests.swift
+++ b/SDKTest/SessionTests.swift
@@ -15,7 +15,7 @@ class SessionTests: XCTestCase {
         _ = NeuroID.configure(clientKey: clientKey, isAdvancedDevice: false)
    
         NeuroID._isSDKStarted = true
-        DataStore.removeSentEvents()
+        NeuroID.datastore.removeSentEvents()
 
 
         NeuroID.collectionURL = Constants.productionURL.rawValue

--- a/SDKTest/TouchEventsTests.swift
+++ b/SDKTest/TouchEventsTests.swift
@@ -23,11 +23,11 @@ class TouchEventTests: XCTestCase {
         _ = NeuroID.stop()
 
         // Clear out the DataStore Events after each test
-        DataStore.removeSentEvents()
+        NeuroID.datastore.removeSentEvents()
     }
 
     func assertEventTypeCount(type: String, expectedCount: Int) {
-        let dataStoreEvents = DataStore.getAllEvents()
+        let dataStoreEvents = NeuroID.datastore.getAllEvents()
         let filteredEvents = dataStoreEvents.filter { $0.type == type }
 
         assert(filteredEvents.count == expectedCount)

--- a/SDKTest/UtilFunctionsTests.swift
+++ b/SDKTest/UtilFunctionsTests.swift
@@ -31,11 +31,11 @@ final class UtilFunctionsTests: XCTestCase {
         _ = NeuroID.stop()
 
         // Clear out the DataStore Events after each test
-        DataStore.removeSentEvents()
+        NeuroID.datastore.removeSentEvents()
     }
 
     func getEventOfType(type: String) -> [NIDEvent] {
-        let dataStoreEvents = DataStore.getAllEvents()
+        let dataStoreEvents = NeuroID.datastore.getAllEvents()
         return dataStoreEvents.filter { $0.type == type }
     }
 

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDDataStore.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDDataStore.swift
@@ -1,0 +1,106 @@
+//
+//  NIDDataStore.swift
+//  NeuroID
+//
+//  Created by Kevin Sites on 1/21/25.
+//
+
+import Foundation
+
+extension NeuroID {
+    /**
+        Save and event to the datastore (logic of queue or not contained in this function)
+     */
+    static func saveEventToDataStore(_ event: NIDEvent, screen: String? = nil) {
+        if !NeuroID.isSDKStarted {
+            saveQueuedEventToLocalDataStore(event, screen:screen)
+        } else {
+            saveEventToLocalDataStore(event, screen:screen)
+        }
+    }
+
+    static func saveEventToLocalDataStore(_ event: NIDEvent, screen: String? = nil) {
+        if NeuroID.isStopped() {
+            return
+        }
+        
+        NeuroID.cleanAndStoreEvent(screen: screen ?? event.type, event: event, storeType: "event")
+    }
+
+    static func saveQueuedEventToLocalDataStore(_ event: NIDEvent, screen: String? = nil) {
+        NeuroID.cleanAndStoreEvent(screen: screen ?? event.type, event: event, storeType: "queue")
+    }
+    
+    /**
+            Method to clean incoming events, prevent unwanted events, and attach metadata fields
+     */
+    static func cleanAndStoreEvent(screen: String, event: NIDEvent, storeType: String) {
+       // If we hit a low memory event, drop events and early return
+       //  OR if we are not sampling the session (i.e. are throttling)
+       //  then drop events
+       if NeuroID.lowMemory || !NeuroID.samplingService.isSessionFlowSampled {
+           return
+       }
+        
+       // If queue has more than config event queue size (default 2000), send a queue full event and return
+        if NeuroID.datastore.queuedEvents.count + NeuroID.datastore.events.count > NeuroID.configService.configCache.eventQueueFlushSize {
+            if NeuroID.datastore.events.last?.type != NIDEventName.bufferFull.rawValue, NeuroID.datastore.queuedEvents.last?.type != NIDEventName.bufferFull.rawValue {
+                
+               let fullEvent = NIDEvent(type: NIDEventName.bufferFull)
+               if storeType == "queue" {
+                   NeuroID.datastore.queuedEvents.append(fullEvent)
+               } else {
+                   NeuroID.datastore.events.append(fullEvent)
+               }
+           }
+           NIDLog.d("Warning, NeuroID DataStore is full. Event dropped: \(event.type)")
+           return
+       }
+
+       let mutableEvent = event
+
+       // Do not capture any events bound to RNScreensNavigationController as we will double count if we do
+       if let eventURL = mutableEvent.url {
+           if eventURL.contains("RNScreensNavigationController") {
+               return
+           }
+       }
+
+       // Grab the current set screen and set event URL to this
+       mutableEvent.url = "ios://\(NeuroID.getScreenName() ?? "")"
+
+       if mutableEvent.tg?["\(Constants.tgsKey.rawValue)"] != nil {
+           if NeuroID.excludedViewsTestIDs.contains(where: { $0 == mutableEvent.tg!["\(Constants.tgsKey.rawValue)"]!.toString() }) {
+               return
+           }
+       }
+
+       // Ensure this event is not on the exclude list
+       if NeuroID.excludedViewsTestIDs.contains(where: { $0 == mutableEvent.tgs || $0 == mutableEvent.en }) {
+           return
+       }
+
+       let sensorManager = NIDSensorManager.shared
+       mutableEvent.gyro = sensorManager.getSensorData(sensor: .gyro)
+       mutableEvent.accel = sensorManager.getSensorData(sensor: .accelerometer)
+
+       NeuroID.logDebug(category: "Sensor Accel", content: sensorManager.isSensorAvailable(.accelerometer))
+       NeuroID.logDebug(category: "Sensor Gyro", content: sensorManager.isSensorAvailable(.gyro))
+       NeuroID.logDebug(category: "saveEvent", content: mutableEvent.toDict())
+
+        NeuroID.datastore.insertCleanedEvent(event: mutableEvent, storeType: storeType)
+   }
+    
+    static func clearDataStore(){
+        NeuroID.datastore.events = []
+        NeuroID.datastore.queuedEvents = []
+    }
+    
+    static func moveQueuedEventsToDataStore(){
+        let queuedEvents = NeuroID.datastore.getAndRemoveAllQueuedEvents()
+        for event in queuedEvents {
+            NeuroID.saveEventToLocalDataStore(event)
+        }
+
+    }
+}

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDSend.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDSend.swift
@@ -112,7 +112,7 @@ extension NeuroID {
         }
 
         // get and clear event queue
-        let dataStoreEvents = DataStore.getAndRemoveAllEvents()
+        let dataStoreEvents = NeuroID.datastore.getAndRemoveAllEvents()
 
         if dataStoreEvents.isEmpty {
             completion()

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -286,11 +286,8 @@ extension NeuroID {
         //  this will be refactored once we bring start/startSession in alignment
         customFunctionality()
 
-        let queuedEvents = DataStore.getAndRemoveAllQueuedEvents()
-        for event in queuedEvents {
-            DataStore.insertEvent(screen: "", event: event)
-        }
-
+        moveQueuedEventsToDataStore()
+       
         captureAdvancedDevice()
 
         completion()
@@ -393,7 +390,7 @@ extension NeuroID {
             return
         } else {
             // if not sampled clear any events that might have slipped through
-            _ = DataStore.getAndRemoveAllEvents()
+            _ = NeuroID.datastore.getAndRemoveAllEvents()
 
             completion()
 

--- a/Source/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroID.swift
@@ -23,6 +23,7 @@ public class NeuroID: NSObject {
     static var siteID: String?
     static var linkedSiteID: String?
 
+    static var datastore: DataStore = DataStore()
     static var locationManager: LocationManagerService?
     static var networkMonitor: NetworkMonitoringService?
     static var callObserver: NIDCallStatusObserverService?
@@ -96,7 +97,13 @@ public class NeuroID: NSObject {
 
         if !validateClientKey(clientKey) {
             NIDLog.e("Invalid Client Key")
-            saveQueuedEventToLocalDataStore(NIDEvent(type: NIDEventName.log, level: "ERROR", m: "Invalid Client Key \(clientKey)"))
+            saveQueuedEventToLocalDataStore(
+                NIDEvent(
+                    type: NIDEventName.log,
+                    level: "ERROR",
+                    m: "Invalid Client Key \(clientKey)"
+                )
+            )
             setUserDefaultKey(Constants.storageTabIDKey.rawValue, value: ParamsCreator.getTabId() + "-invalid-client-key")
 
             return false
@@ -188,24 +195,7 @@ public class NeuroID: NSObject {
         didSwizzle.toggle()
     }
 
-    /**
-        Save and event to the datastore (logic of queue or not contained in this function)
-     */
-    static func saveEventToDataStore(_ event: NIDEvent) {
-        if !NeuroID.isSDKStarted {
-            saveQueuedEventToLocalDataStore(event)
-        } else {
-            saveEventToLocalDataStore(event)
-        }
-    }
-
-    static func saveEventToLocalDataStore(_ event: NIDEvent) {
-        DataStore.insertEvent(screen: event.type, event: event)
-    }
-
-    static func saveQueuedEventToLocalDataStore(_ event: NIDEvent) {
-        DataStore.insertQueuedEvent(screen: event.type, event: event)
-    }
+    
 
     /// Get the current SDK versión from bundle
     /// - Returns: String with the version format

--- a/Source/NeuroID/NeuroIDTracker.swift
+++ b/Source/NeuroID/NeuroIDTracker.swift
@@ -30,7 +30,7 @@ public class NeuroIDTracker: NSObject {
         let newEvent = event
         // Make sure we have a valid url set
         newEvent.url = NeuroID.getScreenName()
-        DataStore.insertEvent(screen: screenName, event: newEvent)
+        NeuroID.saveEventToLocalDataStore(newEvent, screen: screenName)
     }
     
     public static func registerSingleView(

--- a/Source/NeuroID/TrackerClassExtensions/UIClassExtensions/UIViewController.swift
+++ b/Source/NeuroID/TrackerClassExtensions/UIClassExtensions/UIViewController.swift
@@ -221,7 +221,7 @@ extension UIViewController {
 
             // Make sure we have a valid url set
             event.url = nidClassName
-            DataStore.insertEvent(screen: nidClassName, event: event)
+            NeuroID.saveEventToLocalDataStore(event, screen: nidClassName)
         }
     }
 
@@ -239,6 +239,7 @@ extension UIViewController {
 
         // Make sure we have a valid url set
         event.url = nidClassName
-        DataStore.insertEvent(screen: nidClassName, event: event)
+        
+        NeuroID.saveEventToLocalDataStore(event, screen: nidClassName)
     }
 }

--- a/Source/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/Source/NeuroID/TrackerClassExtensions/Utils.swift
@@ -190,7 +190,8 @@ enum UtilFunctions {
         let screenName = className ?? ParamsCreator.generateID()
         // Make sure we have a valid url set
         event.url = screenName
-        DataStore.insertEvent(screen: screenName, event: event)
+        
+        NeuroID.saveEventToLocalDataStore(event, screen: screenName)
     }
 
     static func captureTextEvents(view: UIView, textValue: String, eventType: NIDEventName) {

--- a/Source/NeuroID/TrackerEvents/AppEvents.swift
+++ b/Source/NeuroID/TrackerEvents/AppEvents.swift
@@ -37,8 +37,8 @@ extension NeuroIDTracker {
         // Reduce memory footprint
         // Only clear this event queue the first time as it might be triggered a few times in a row (dropping our low mem event)
         if !NeuroID.lowMemory {
-            DataStore.events = []
-            DataStore.queuedEvents = []
+            NeuroID.clearDataStore()
+            
             let lowMemEvent = NIDEvent(type: NIDEventName.lowMemory)
             lowMemEvent.url = NeuroID.getScreenName()
 

--- a/Source/NeuroID/TrackerEvents/TouchEvents.swift
+++ b/Source/NeuroID/TrackerEvents/TouchEvents.swift
@@ -113,5 +113,5 @@ func captureTouchEvent(
     newEvent.touches = touchArray
     // Make sure we have a valid url set
     newEvent.url = NeuroID.getScreenName()
-    DataStore.insertEvent(screen: viewClass, event: newEvent)
+    NeuroID.saveEventToLocalDataStore(newEvent, screen: viewClass)
 }


### PR DESCRIPTION
Make our Datastore a class instance instead of static. This is part 1 but I am breaking it up because the changes are so large. 

Future updates will make it so each testing group gets an individual instance of the class so that cross-tests will not impact each other.