### PR TITLE
ENG-9335 add last install time

### DIFF
--- a/SDKTest/DataStoreTests.swift
+++ b/SDKTest/DataStoreTests.swift
@@ -195,4 +195,14 @@ class DataStoreTests: XCTestCase {
         let value = UserDefaults.standard.bool(forKey: testStoreKey)
         assert(value == true)
     }
+    
+    func test_getUserDefaultKeyDouble_no_value() {
+        UserDefaults.standard.removeObject(forKey: "test_key")
+        assert(getUserDefaultKeyDouble("test_key") == 0)
+    }
+    
+    func test_getUserDefaultKeyDouble_valid_value() {
+        setUserDefaultKey("test_key", value: 15.0)
+        assert(getUserDefaultKeyDouble("test_key") == 15.0)
+    }
 }

--- a/Source/NeuroID/Constants.swift
+++ b/Source/NeuroID/Constants.swift
@@ -43,6 +43,7 @@ enum Constants: String {
     case etKey = "et"
     case vKey = "v"
     case hashKey = "hash"
+    case lastInstallTime = "lastInstallTime"
 
     // Tags
     case debugTag = "NeuroID Debug:"

--- a/Source/NeuroID/DataStore.swift
+++ b/Source/NeuroID/DataStore.swift
@@ -63,6 +63,10 @@ internal func getUserDefaultKeyString(_ key: String) -> String? {
     return UserDefaults.standard.string(forKey: key)
 }
 
+internal func getUserDefaultKeyDouble(_ key: String) -> Double {
+    return UserDefaults.standard.double(forKey: key)
+}
+
 internal func getUserDefaultKeyDict(_ key: String) -> [String: Any]? {
     return UserDefaults.standard.dictionary(forKey: key)
 }

--- a/Source/NeuroID/NIDMetadata.swift
+++ b/Source/NeuroID/NIDMetadata.swift
@@ -51,7 +51,7 @@ final class NIDMetadata: Codable {
         self.batteryLevel = NIDMetadata.getBaterryLevel()
         self.isJailBreak = NIDMetadata.hasJailbreak()
         self.isSimulator = NIDMetadata.isSimulator()
-        self.lastInstallTime = Int64(UserDefaults.standard.integer(forKey: "lastInstallTime") * 1000)
+        self.lastInstallTime = Int64(getUserDefaultKeyDouble("lastInstallTime")) * 1000
         self.gpsCoordinates = NIDLocation(
             latitude: NeuroID.locationManager?.latitude ?? -1,
             longitude: NeuroID.locationManager?.longitude ?? -1,

--- a/Source/NeuroID/NIDMetadata.swift
+++ b/Source/NeuroID/NIDMetadata.swift
@@ -34,6 +34,7 @@ final class NIDMetadata: Codable {
     var isWifiOn: Bool
     var isSimulator: Bool
     var gpsCoordinates: NIDLocation
+    var lastInstallTime: Int64
 
     // Init with local data
     public init() {
@@ -50,7 +51,7 @@ final class NIDMetadata: Codable {
         self.batteryLevel = NIDMetadata.getBaterryLevel()
         self.isJailBreak = NIDMetadata.hasJailbreak()
         self.isSimulator = NIDMetadata.isSimulator()
-
+        self.lastInstallTime = Int64(UserDefaults.standard.integer(forKey: "lastInstallTime") * 1000)
         self.gpsCoordinates = NIDLocation(
             latitude: NeuroID.locationManager?.latitude ?? -1,
             longitude: NeuroID.locationManager?.longitude ?? -1,

--- a/Source/NeuroID/NIDMetadata.swift
+++ b/Source/NeuroID/NIDMetadata.swift
@@ -51,7 +51,7 @@ final class NIDMetadata: Codable {
         self.batteryLevel = NIDMetadata.getBaterryLevel()
         self.isJailBreak = NIDMetadata.hasJailbreak()
         self.isSimulator = NIDMetadata.isSimulator()
-        self.lastInstallTime = Int64(getUserDefaultKeyDouble("lastInstallTime")) * 1000
+        self.lastInstallTime = Int64(getUserDefaultKeyDouble("lastInstallTime") * 1000)
         self.gpsCoordinates = NIDLocation(
             latitude: NeuroID.locationManager?.latitude ?? -1,
             longitude: NeuroID.locationManager?.longitude ?? -1,

--- a/Source/NeuroID/NIDMetadata.swift
+++ b/Source/NeuroID/NIDMetadata.swift
@@ -51,7 +51,7 @@ final class NIDMetadata: Codable {
         self.batteryLevel = NIDMetadata.getBaterryLevel()
         self.isJailBreak = NIDMetadata.hasJailbreak()
         self.isSimulator = NIDMetadata.isSimulator()
-        self.lastInstallTime = Int64(getUserDefaultKeyDouble("lastInstallTime") * 1000)
+        self.lastInstallTime = Int64(getUserDefaultKeyDouble(Constants.lastInstallTime.rawValue) * 1000)
         self.gpsCoordinates = NIDLocation(
             latitude: NeuroID.locationManager?.latitude ?? -1,
             longitude: NeuroID.locationManager?.longitude ?? -1,

--- a/Source/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroID.swift
@@ -92,8 +92,8 @@ public class NeuroID: NSObject {
     /// 3. Send cached events from DB every `SEND_INTERVAL`
     public static func configure(clientKey: String, isAdvancedDevice: Bool = false) -> Bool {
         // set last install time if not already set.
-        if (getUserDefaultKeyDouble("lastInstallTime") == 0) {
-            setUserDefaultKey("lastInstallTime", value: (Date().timeIntervalSince1970))
+        if (getUserDefaultKeyDouble(Constants.lastInstallTime.rawValue) == 0) {
+            setUserDefaultKey(Constants.lastInstallTime.rawValue, value: (Date().timeIntervalSince1970))
         }
         
         if NeuroID.clientKey != nil {

--- a/Source/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroID.swift
@@ -92,9 +92,8 @@ public class NeuroID: NSObject {
     /// 3. Send cached events from DB every `SEND_INTERVAL`
     public static func configure(clientKey: String, isAdvancedDevice: Bool = false) -> Bool {
         // set last install time if not already set.
-        if (UserDefaults.standard.object(forKey: "lastInstallTime") == nil) {
-            UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "lastInstallTime")
-            UserDefaults.standard.synchronize()
+        if (getUserDefaultKeyDouble("lastInstallTime") == 0) {
+            setUserDefaultKey("lastInstallTime", value: (Date().timeIntervalSince1970))
         }
         
         if NeuroID.clientKey != nil {

--- a/Source/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroID.swift
@@ -91,6 +91,12 @@ public class NeuroID: NSObject {
     /// 2. Setup silent running loop
     /// 3. Send cached events from DB every `SEND_INTERVAL`
     public static func configure(clientKey: String, isAdvancedDevice: Bool = false) -> Bool {
+        // set last install time if not already set.
+        if (UserDefaults.standard.object(forKey: "lastInstallTime") == nil) {
+            UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "lastInstallTime")
+            UserDefaults.standard.synchronize()
+        }
+        
         if NeuroID.clientKey != nil {
             NIDLog.e("You already configured the SDK")
             return false


### PR DESCRIPTION
Add the last install time in metadata. Below is a screenshot of the lastInstallTime in the metadata request body from WormHoly in the updated NeuroID iOS SDK running on the NeuroID SDK Swift sample app. 

<img width="464" alt="Screenshot 2025-02-25 at 9 20 13 PM" src="https://github.com/user-attachments/assets/e36a6b31-d7a7-407b-ba0a-1d730c18f247" />
