### PR TITLE
Eng 9499 spm version fix

### DIFF
--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -86,6 +86,8 @@ jobs:
       - name: Get Updated Version
         run: |
           PACKAGE_VERSION=$(bundle exec fastlane get_project_version | grep -o "SDK Version:.*" | sed "s/SDK Version: //" )
+	  chmod +x ./Scripts/update_version.sh
+	  ./Scripts/update_version $PACKAGE_VERSION Source/NeuroID/NIDParamsCreator.swift
           echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_ENV
           echo "BRANCH_NAME=releases/${PACKAGE_VERSION}_version_update" >> $GITHUB_ENV
 
@@ -107,6 +109,7 @@ jobs:
           set +e
           git add NeuroID.podspec
           git add NeuroID/Info.plist
+	  git add NeuroID/Source/NeuroID/NIDParamsCreator.swift
           git commit -m "Update SDK to $PACKAGE_VERSION"
           git tag "v$PACKAGE_VERSION"
           git push --set-upstream origin ${{ env.BRANCH_NAME }}

--- a/SDKTest/NIDParamsCreatorTests.swift
+++ b/SDKTest/NIDParamsCreatorTests.swift
@@ -433,4 +433,10 @@ class NIDParamsCreatorTests: XCTestCase {
 
         assert(value != secondValue)
     }
+    
+    func test_getSPVersionID() {
+        let expectedValue = "3.4.5"
+        let value = ParamsCreator.getSPVersionID(version: "%%%3.4.5%%%")
+        assert(value == expectedValue)
+    }
 }

--- a/Scripts/update_version.sh
+++ b/Scripts/update_version.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "usage $0 <version> <swift_file>"
+    exit 1
+fi
+
+VERSION="$1"
+SWIFT_FILE="$2"
+
+sed -i.bak "s/%%%Version%%%/$VERSION/" "$SWIFT_FILE"
+
+rm "$SWIFT_FILE.bak"
+
+echo "updated $SWIFT_FILE; set version to \"$VERSION\""

--- a/Scripts/update_version.sh
+++ b/Scripts/update_version.sh
@@ -10,7 +10,7 @@ fi
 VERSION="$1"
 SWIFT_FILE="$2"
 
-sed -i.bak "s/%%%Version%%%/$VERSION/" "$SWIFT_FILE"
+sed -i.bak "s/%%%[^%]*%%%/%%%$VERSION%%%/" "$SWIFT_FILE"
 
 rm "$SWIFT_FILE.bak"
 

--- a/Source/NeuroID/NIDParamsCreator.swift
+++ b/Source/NeuroID/NIDParamsCreator.swift
@@ -183,6 +183,8 @@ enum ParamsCreator {
         // Get Version number from bundled info.plist file if included
         if let bundleURL = Bundle(for: NeuroIDTracker.self).url(forResource: "NeuroID", withExtension: "bundle") {
             version = Bundle(url: bundleURL)?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        } else {
+            version = "%%%Version%%%"
         }
         return "5.ios\(NeuroID.isRN ? "-rn" : "")-adv-\(version ?? "?")"
     }

--- a/Source/NeuroID/NIDParamsCreator.swift
+++ b/Source/NeuroID/NIDParamsCreator.swift
@@ -184,7 +184,7 @@ enum ParamsCreator {
         if let bundleURL = Bundle(for: NeuroIDTracker.self).url(forResource: "NeuroID", withExtension: "bundle") {
             version = Bundle(url: bundleURL)?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         } else {
-            version = "%%%Version%%%"
+            version = getSPVersionID(version: "%%%3.4.2%%%")
         }
         return "5.ios\(NeuroID.isRN ? "-rn" : "")-adv-\(version ?? "?")"
     }
@@ -198,5 +198,21 @@ enum ParamsCreator {
         let now = Date().timeIntervalSince1970 * 1000
         let rawId = (Int(now) - 1488084578518) * 1024 + (x + 1)
         return String(format: "%02X", rawId)
+    }
+    
+    static func getSPVersionID(version: String) -> String {
+        var spVersion = version
+        
+        // extract version from the sp version string
+        guard let regex = try? NSRegularExpression(pattern: "%%%([^%]*)%%%") else {
+            return spVersion
+        }
+        if let match = regex.firstMatch(in: spVersion, options: [], range: NSRange(spVersion.startIndex..., in: spVersion)) {
+            if let range = Range(match.range(at: 1), in: spVersion) {
+                let extracted = String(spVersion[range])
+                spVersion = extracted
+            }
+        }
+        return spVersion
     }
 }


### PR DESCRIPTION
Swift package builds will not show proper version. This PR addresses that. The github action will call update_version.sh to fill in the SDK version directly into the getSDKVersion() function at release time.  