### PR TITLE
ENG-9499 fix formatting and file locations to make script work

### DIFF
--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -86,10 +86,14 @@ jobs:
       - name: Get Updated Version
         run: |
           PACKAGE_VERSION=$(bundle exec fastlane get_project_version | grep -o "SDK Version:.*" | sed "s/SDK Version: //" )
-	  chmod +x ./Scripts/update_version.sh
-	  ./Scripts/update_version $PACKAGE_VERSION Source/NeuroID/NIDParamsCreator.swift
           echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_ENV
           echo "BRANCH_NAME=releases/${PACKAGE_VERSION}_version_update" >> $GITHUB_ENV
+
+      - name: make update_version script executable
+        run: chmod +x ./Scripts/update_version.sh
+
+      - name: run update_version script
+        run: ./Scripts/update_version.sh $PACKAGE_VERSION Source/NeuroID/NIDParamsCreator.swift
 
       - name: Get previous release tag
         run: echo TAG="$(git describe --abbrev=0 --tags --match 'v*')" >> $GITHUB_ENV
@@ -108,8 +112,8 @@ jobs:
           git status
           set +e
           git add NeuroID.podspec
-          git add NeuroID/Info.plist
-	  git add NeuroID/Source/NeuroID/NIDParamsCreator.swift
+          git add Source/NeuroID/Info.plist
+          git add Source/NeuroID/NIDParamsCreator.swift
           git commit -m "Update SDK to $PACKAGE_VERSION"
           git tag "v$PACKAGE_VERSION"
           git push --set-upstream origin ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
fix formatting and file locations to make script work

you can see a run here: 
https://github.com/kishisaka-nid/neuroid-ios-sdk-version-fix/actions/runs/14371361930/job/40294894560

I am getting this error here. I am hopping it is just my fork and will not occur on the actual repo. 

```
Run git config --global user.email developer@neuro-id.com
  git config --global user.email developer@neuro-id.com
  git config --global user.name neuroid-developer
  git checkout -b releases/[2](https://github.com/kishisaka-nid/neuroid-ios-sdk-version-fix/actions/runs/14371361930/job/40294894560#step:18:2).3.1_version_update
  git status
  set +e
  git add NeuroID.podspec
  git add Source/NeuroID/Info.plist
  git add Source/NeuroID/NIDParamsCreator.swift
  git commit -m "Update SDK to $PACKAGE_VERSION"
  git tag "v$PACKAGE_VERSION"
  git push --set-upstream origin releases/2.[3](https://github.com/kishisaka-nid/neuroid-ios-sdk-version-fix/actions/runs/14371361930/job/40294894560#step:18:3).1_version_update
  set -e
  shell: /bin/bash -e {0}
  env:
    PATH: /Users/runner/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/runner/.cargo/bin:/usr/local/opt/curl/bin:/usr/local/bin:/usr/local/sbin:/Users/runner/bin:/Users/runner/.yarn/bin:/Users/runner/Library/Android/sdk/tools:/Users/runner/Library/Android/sdk/platform-tools:/Library/Frameworks/Python.framework/Versions/Current/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/usr/bin:/bin:/usr/sbin:/sbin:/Users/runner/.dotnet/tools
    PACKAGE_VERSION: 2.3.1
    BRANCH_NAME: releases/2.3.1_version_update
    TAG: 
    HASH: 7[4](https://github.com/kishisaka-nid/neuroid-ios-sdk-version-fix/actions/runs/14371361930/job/40294894560#step:18:4)9f683823f7b40b2e58a47757a730ac515ff88e
    URL: https://github.com/Neuro-ID/neuroid-ios-sdk/compare/...749f683823f7b40b2e[5](https://github.com/kishisaka-nid/neuroid-ios-sdk-version-fix/actions/runs/14371361930/job/40294894560#step:18:5)8a47757a730ac515ff88e
Switched to a new branch 'releases/2.3.1_version_update'
On branch releases/2.3.1_version_update
Changes not staged for commit:
	modified:   NeuroID.podspec
	modified:   SDKTest/Info.plist
	modified:   SDKUITest/Info.plist
	modified:   Scripts/update_version.sh
	modified:   Source/NeuroID/Info.plist

Untracked files:
	.bundle/
	vendor/

no changes added to commit
[releases/2.3.1_version_update c8d[7](https://github.com/kishisaka-nid/neuroid-ios-sdk-version-fix/actions/runs/14371361930/job/40294894560#step:18:7)0fe] Update SDK to 2.3.1
 2 files changed, 2 insertions(+), 2 deletions(-)
To https://github.com/kishisaka-nid/neuroid-ios-sdk-version-fix
 ! [rejected]        releases/2.3.1_version_update -> releases/2.3.1_version_update (non-fast-forward)
error: failed to push some refs to 'https://github.com/kishisaka-nid/neuroid-ios-sdk-version-fix'
```