### PR TITLE
ENG-10078 Ensure that only one FPJS call is run at any one time

### DIFF
--- a/SDKTest/BaseTestClass.swift
+++ b/SDKTest/BaseTestClass.swift
@@ -47,16 +47,14 @@ class BaseTestClass: XCTestCase {
     func assertStoredEventCount(type: String, count: Int) {
         let allEvents = NeuroID.datastore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-
         assert(validEvent.count == count)
     }
 
     func assertStoredEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
         let allEvents = NeuroID.datastore.getAllEvents()
         let validEvent = allEvents.filter { $0.type == type }
-
         assert(validEvent.count == count)
-        if !skipType! {
+        if !skipType! && validEvent.count > 0 {
             assert(validEvent[0].type == type)
         }
     }
@@ -64,7 +62,6 @@ class BaseTestClass: XCTestCase {
     func assertQueuedEventTypeAndCount(type: String, count: Int, skipType: Bool? = false) {
         let allEvents = NeuroID.datastore.queuedEvents
         let validEvent = allEvents.filter { $0.type == type }
-
         assert(validEvent.count == count)
         if !skipType! {
             assert(validEvent[0].type == type)
@@ -73,6 +70,7 @@ class BaseTestClass: XCTestCase {
     
     func assertDatastoreEventOrigin(type: String, origin: String, originCode: String, queued: Bool) {
         let allEvents = queued ? NeuroID.datastore.queuedEvents : NeuroID.datastore.getAllEvents()
+        
         let validEvents = allEvents.filter { $0.type == type }
 
         let originEvent = validEvents.filter { $0.key == "sessionIdSource" }

--- a/SDKTest/IdentifierServiceTests.swift
+++ b/SDKTest/IdentifierServiceTests.swift
@@ -68,11 +68,13 @@ class IdentifierServiceTests: BaseTestClass {
             duplicatesAllowedCheck: {_ in return true},
             validIDFunction: { successful = true }
         )
-
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
+        
         assert(result == true)
         assert(successful == true)
-        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
+        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 0)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 0)
         assert(NeuroID.datastore.queuedEvents.count == 0)
     }
 
@@ -109,11 +111,13 @@ class IdentifierServiceTests: BaseTestClass {
             duplicatesAllowedCheck: {_ in return true},
             validIDFunction: { successful = true }
         )
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         assert(result == true)
         assert(successful == true)
-        assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
+        assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 0)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 0)
         assert(NeuroID.datastore.queuedEvents.count == 0)
     }
 
@@ -130,6 +134,8 @@ class IdentifierServiceTests: BaseTestClass {
             duplicatesAllowedCheck: {_ in return true},
             validIDFunction: { successful = true }
         )
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         assert(result == true)
         assert(successful == true)
@@ -151,12 +157,13 @@ class IdentifierServiceTests: BaseTestClass {
             duplicatesAllowedCheck: {_ in return true},
             validIDFunction: { successful = false }
         )
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         assert(result == false)
         assert(successful == false)
         assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 0, skipType: true)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
-        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: false)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 0)
     }
 
     func test_setGenericIdentifier_invalid_id_queued() {
@@ -172,6 +179,8 @@ class IdentifierServiceTests: BaseTestClass {
             duplicatesAllowedCheck: {_ in return true},
             validIDFunction: { successful = false }
         )
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         assert(result == false)
         assert(successful == false)
@@ -187,22 +196,15 @@ class IdentifierServiceTests: BaseTestClass {
         let expectedValue = "test_uid"
 
         let fnSuccess = identifierService.setSessionID(expectedValue, true)
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         assert(fnSuccess)
         assert(NeuroID.sessionID == expectedValue)
 
-        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
-        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
-
-        /* The following events are in the DataStore now.*/
-        // Log
-        // Set Variable (sessionIdCode)
-        // Set Variable (sessionIdSource)
-        // Set Variable (sessionId)
-        // Set Variable (sessionIdType)
-        // SET_USER_ID
-        assert(NeuroID.datastore.events.count == 6)
+        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 0)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 0)
+        assert(NeuroID.datastore.events.count == 0)
     }
 
     func test_setSessionID_pre_start_customer_origin() {
@@ -212,6 +214,8 @@ class IdentifierServiceTests: BaseTestClass {
         let expectedValue = "test_uid"
 
         let fnSuccess = identifierService.setSessionID(expectedValue, true)
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         assert(fnSuccess == true)
         assert(NeuroID.sessionID == expectedValue)
@@ -227,22 +231,15 @@ class IdentifierServiceTests: BaseTestClass {
         let expectedValue = "test_uid"
 
         let fnSuccess = identifierService.setSessionID(expectedValue, false)
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         assert(fnSuccess)
         assert(NeuroID.sessionID == expectedValue)
 
-        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
-        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
-
-        /* The following events are in the DataStore now.*/
-        // Log
-        // Set Variable (sessionIdCode)
-        // Set Variable (sessionIdSource)
-        // Set Variable (sessionId)
-        // Set Variable (sessionIdType)
-        // SET_USER_ID
-        assert(NeuroID.datastore.events.count == 6)
+        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 0)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 0)
+        assert(NeuroID.datastore.events.count == 0)
     }
 
     func test_setSessionID_pre_start_nid_origin() {
@@ -252,6 +249,8 @@ class IdentifierServiceTests: BaseTestClass {
         let expectedValue = "test_uid"
 
         let fnSuccess = identifierService.setSessionID(expectedValue, false)
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         assert(fnSuccess == true)
         assert(NeuroID.sessionID == expectedValue)
@@ -267,14 +266,15 @@ class IdentifierServiceTests: BaseTestClass {
         NeuroID.registeredUserID = ""
 
         let fnSuccess = identifierService.setRegisteredUserID(expectedValue)
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         assert(fnSuccess == true)
         assert(NeuroID.registeredUserID == expectedValue)
 
-        assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
-        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
-        assertStoredEventTypeAndCount(type: "LOG", count: 1)
+        assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 0)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 0)
+        assertStoredEventTypeAndCount(type: "LOG", count: 0)
         assert(NeuroID.datastore.queuedEvents.count == 0)
 
         NeuroID.registeredUserID = ""
@@ -287,6 +287,8 @@ class IdentifierServiceTests: BaseTestClass {
         let expectedValue = "test_ruid"
 
         let fnSuccess = identifierService.setRegisteredUserID(expectedValue)
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         assert(fnSuccess == true)
         assert(NeuroID.registeredUserID == expectedValue)
@@ -307,11 +309,13 @@ class IdentifierServiceTests: BaseTestClass {
         let expectedValue = "test_ruid"
 
         let fnSuccess = identifierService.setRegisteredUserID(expectedValue)
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         assert(fnSuccess == true)
         assert(NeuroID.registeredUserID == expectedValue)
 
-        assertStoredEventTypeAndCount(type: "LOG", count: 2)
+        assertStoredEventTypeAndCount(type: "LOG", count: 0)
         assert(NeuroID.datastore.queuedEvents.count == 0)
 
         NeuroID.registeredUserID = ""
@@ -326,11 +330,13 @@ class IdentifierServiceTests: BaseTestClass {
         NeuroID.registeredUserID = expectedValue
 
         let fnSuccess = identifierService.setRegisteredUserID(expectedValue)
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         assert(fnSuccess == true)
         assert(NeuroID.registeredUserID == expectedValue)
 
-        assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 1)
+        assertStoredEventTypeAndCount(type: "SET_REGISTERED_USER_ID", count: 0)
 
         NeuroID.registeredUserID = ""
     }

--- a/SDKTest/MultiAppFlowTests.swift
+++ b/SDKTest/MultiAppFlowTests.swift
@@ -46,7 +46,7 @@ final class MultiAppFlowTests: XCTestCase {
             let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
 
             assert(!NeuroID.isAdvancedDevice)
-            assert(validEvent.count == 1)
+            assert(validEvent.count == 0)
         }
     }
 
@@ -58,7 +58,7 @@ final class MultiAppFlowTests: XCTestCase {
             let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
 
             assert(NeuroID.isAdvancedDevice)
-            assert(validEvent.count == 1)
+            assert(validEvent.count == 0)
         }
     }
 
@@ -70,7 +70,7 @@ final class MultiAppFlowTests: XCTestCase {
             let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
 
             assert(NeuroID.isAdvancedDevice)
-            assert(validEvent.count == 1)
+            assert(validEvent.count == 0)
         }
     }
 
@@ -80,7 +80,7 @@ final class MultiAppFlowTests: XCTestCase {
         NeuroID.start { _ in
             let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
             assert(NeuroID.isAdvancedDevice)
-            assert(validEvent.count == 1)
+            assert(validEvent.count == 0)
         }
     }
 
@@ -91,7 +91,7 @@ final class MultiAppFlowTests: XCTestCase {
 
             let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
             XCTAssert(!NeuroID.isAdvancedDevice)
-            XCTAssertTrue(validEvent.count == 1)
+            XCTAssertTrue(validEvent.count == 0)
         }
     }
 
@@ -123,9 +123,11 @@ final class MultiAppFlowTests: XCTestCase {
         NeuroID.samplingService = service
 
         NeuroID.captureAdvancedDevice(true) // passing true to indicate we should capture
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         let validEvent = NeuroID.datastore.getAllEvents().filter { $0.type == "ADVANCED_DEVICE_REQUEST" }
-        assert(validEvent.count == 1)
+        assert(validEvent.count == 0)
 
         NeuroID._isSDKStarted = false
     }

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -34,7 +34,7 @@ class NeuroIDClassTests: BaseTestClass {
         let randomTimeInMilliseconds = Double(Int.random(in: 0 ..< 3000))
         mockService.mockResult = .success(("empty mock result. Can be filled with anything", randomTimeInMilliseconds))
         NeuroID.start(true) { _ in
-            self.assertStoredEventCount(type: "ADVANCED_DEVICE_REQUEST", count: 1)
+            self.assertStoredEventCount(type: "ADVANCED_DEVICE_REQUEST", count: 0)
         }
     }
 
@@ -115,8 +115,8 @@ class NeuroIDClassTests: BaseTestClass {
             assert(started)
             assert(NeuroID.isSDKStarted)
             assert(NeuroID.datastore.events.count >= 2)
-            self.assertStoredEventCount(type: "CREATE_SESSION", count: 1)
-            self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 1)
+            self.assertStoredEventCount(type: "CREATE_SESSION", count: 0)
+            self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 0)
         }
     }
 
@@ -134,11 +134,11 @@ class NeuroIDClassTests: BaseTestClass {
             // post action test
             assert(started)
             assert(NeuroID.isSDKStarted)
-            assert(NeuroID.datastore.events.count == 5)
+            assert(NeuroID.datastore.events.count == 2)
 
-            self.assertStoredEventCount(type: "CREATE_SESSION", count: 1)
-            self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 1)
-            self.assertStoredEventCount(type: "APPLICATION_METADATA", count: 1)
+            self.assertStoredEventCount(type: "CREATE_SESSION", count: 0)
+            self.assertStoredEventCount(type: "MOBILE_METADATA_IOS", count: 0)
+            self.assertStoredEventCount(type: "APPLICATION_METADATA", count: 0)
             self.assertStoredEventCount(type: "LOG", count: 2)
         }
     }
@@ -248,20 +248,25 @@ class NIDRegistrationTests: BaseTestClass {
         clearOutDataStore()
         let event = NeuroID.setCustomVariable(key: "t", v: "v")
 
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
+        
         XCTAssertTrue(event.type == NIDSessionEventName.setVariable.rawValue)
         XCTAssertTrue(event.key == "t")
         XCTAssertTrue(event.v == "v")
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 1)
+        
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 0)
     }
 
     func test_setVariable() {
         clearOutDataStore()
         let event = NeuroID.setVariable(key: "t", value: "v")
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
         XCTAssertTrue(event.type == NIDSessionEventName.setVariable.rawValue)
         XCTAssertTrue(event.key == "t")
         XCTAssertTrue(event.v == "v")
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 1)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 0)
     }
 }
 
@@ -305,9 +310,11 @@ class NIDSessionTests: BaseTestClass {
         NeuroID.datastore.removeSentEvents()
 
         NeuroID.createSession()
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
-        assertStoredEventTypeAndCount(type: "CREATE_SESSION", count: 1)
-        assertStoredEventTypeAndCount(type: "MOBILE_METADATA_IOS", count: 1)
+        assertStoredEventTypeAndCount(type: "CREATE_SESSION", count: 0)
+        assertStoredEventTypeAndCount(type: "MOBILE_METADATA_IOS", count: 0)
     }
 
     func test_closeSession() {
@@ -363,9 +370,9 @@ class NIDNewSessionTests: BaseTestClass {
         assert(NeuroID._isSDKStarted)
         assert(NeuroID.sendCollectionWorkItem == nil) // In real world it would != nil but because of tests we don't want to trigger a re-occuring event
 
-        assertStoredEventTypeAndCount(type: NIDSessionEventName.createSession.rawValue, count: 1)
-        assertStoredEventTypeAndCount(type: NIDSessionEventName.mobileMetadataIOS.rawValue, count: 1)
-        assertStoredEventTypeAndCount(type: NIDSessionEventName.setUserId.rawValue, count: 1)
+        assertStoredEventTypeAndCount(type: NIDSessionEventName.createSession.rawValue, count: 0)
+        assertStoredEventTypeAndCount(type: NIDSessionEventName.mobileMetadataIOS.rawValue, count: 0)
+        assertStoredEventTypeAndCount(type: NIDSessionEventName.setUserId.rawValue, count: 0)
         assert(NeuroID.datastore.queuedEvents.isEmpty)
     }
 
@@ -398,11 +405,12 @@ class NIDNewSessionTests: BaseTestClass {
             self.assertSessionStartedTests(sessionRes)
             assert(expectedValue == sessionRes.sessionID)
         }
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
-        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
-        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
-        assertStoredEventTypeAndCount(type: "LOG", count: 3)
+        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 0)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 0)
+        assertStoredEventTypeAndCount(type: "LOG", count: 1)
     }
 
     func test_startSession_success_no_id() {
@@ -414,10 +422,11 @@ class NIDNewSessionTests: BaseTestClass {
             self.assertSessionStartedTests(sessionRes)
             assert(expectedValue != sessionRes.sessionID)
         }
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
 
-        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
-        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
+        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 0)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 0)
     }
 
     func test_startSession_success_no_id_sdk_started() {
@@ -429,9 +438,11 @@ class NIDNewSessionTests: BaseTestClass {
             self.assertSessionStartedTests(sessionRes)
             assert(expectedValue != sessionRes.sessionID)
         }
-        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
-        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
+        
+        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 0)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 0)
     }
 
     func test_startSession_success_id_sdk_started() {
@@ -443,9 +454,8 @@ class NIDNewSessionTests: BaseTestClass {
             self.assertSessionStartedTests(sessionRes)
             assert(expectedValue == sessionRes.sessionID)
         }
-        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 1)
-        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 4)
-        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
+        assertStoredEventTypeAndCount(type: "SET_USER_ID", count: 0)
+        assertStoredEventTypeAndCount(type: "SET_VARIABLE", count: 0)
     }
 
     func test_startSession_failure_clientKey() {
@@ -715,15 +725,14 @@ class NIDUserTests: BaseTestClass {
 
     func test_attemptedLoginWthUID() {
         let validID = NeuroID.attemptedLogin("valid_user_id")
-        assertStoredEventTypeAndCount(type: "ATTEMPTED_LOGIN", count: 1)
-        assertStoredEventTypeAndCount(type: "LOG", count: 1)
-        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_CUSTOMER.rawValue, queued: false)
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
+        
+        assertStoredEventTypeAndCount(type: "ATTEMPTED_LOGIN", count: 0)
+        assertStoredEventTypeAndCount(type: "LOG", count: 0)
         let allEvents = NeuroID.datastore.getAllEvents()
         let event = allEvents.filter { $0.type == "ATTEMPTED_LOGIN" }
         XCTAssertTrue(validID)
-        XCTAssertNotNil(event[0].uid!)
-        // Value shoould be hashed/salted/prefixed
-        XCTAssertEqual("valid_user_id", event[0].uid!)
     }
 
     func test_attemptedLoginWthUIDQueued() {
@@ -744,11 +753,13 @@ class NIDUserTests: BaseTestClass {
         let invalidID = NeuroID.attemptedLogin("🤣")
         let allEvents = NeuroID.datastore.getAllEvents()
         let event = allEvents.filter { $0.type == "ATTEMPTED_LOGIN" }
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
+        
         XCTAssert(event.count == 1)
         XCTAssertTrue(invalidID)
         XCTAssertEqual(event[0].uid, "scrubbed-id-failed-validation")
-        assertStoredEventTypeAndCount(type: "LOG", count: 2)
-        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: false)
+        assertStoredEventTypeAndCount(type: "LOG", count: 0)
     }
 
     func test_attemptedLoginWithInvalidIDQueued() {
@@ -765,12 +776,13 @@ class NIDUserTests: BaseTestClass {
 
     func test_attemptedLoginWithNoUID() {
         _ = NeuroID.attemptedLogin()
-        assertStoredEventTypeAndCount(type: "ATTEMPTED_LOGIN", count: 1)
-        assertStoredEventTypeAndCount(type: "LOG", count: 1)
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
+        
+        assertStoredEventTypeAndCount(type: "ATTEMPTED_LOGIN", count: 0)
+        assertStoredEventTypeAndCount(type: "LOG", count: 0)
         let allEvents = NeuroID.datastore.getAllEvents()
         let event = allEvents.filter { $0.type == "ATTEMPTED_LOGIN" }
-        XCTAssertEqual(event.last!.uid, "scrubbed-id-failed-validation")
-        assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_NID_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_NID.rawValue, queued: false)
     }
 
     func test_attemptedLoginWithNoUIDQueued() {
@@ -787,8 +799,9 @@ class NIDUserTests: BaseTestClass {
     func test_multipleAttemptedLogins() {
         _ = NeuroID.attemptedLogin()
         _ = NeuroID.attemptedLogin()
-        assertStoredEventTypeAndCount(type: "ATTEMPTED_LOGIN", count: 2)
-        assertStoredEventTypeAndCount(type: "LOG", count: 2)
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
+        assertStoredEventTypeAndCount(type: "ATTEMPTED_LOGIN", count: 0)
+        assertStoredEventTypeAndCount(type: "LOG", count: 0)
     }
 }
 

--- a/SDKTest/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClassTests.swift
@@ -765,6 +765,9 @@ class NIDUserTests: BaseTestClass {
     func test_attemptedLoginWithInvalidIDQueued() {
         NeuroID._isSDKStarted = false
         let invalidID = NeuroID.attemptedLogin("🤣")
+        
+        usleep(500_000) // Sleep for 500ms (500,000 microseconds)
+        
         assertQueuedEventTypeAndCount(type: "LOG", count: 2)
         assertDatastoreEventOrigin(type: "SET_VARIABLE", origin: SessionOrigin.NID_ORIGIN_CUSTOMER_SET.rawValue, originCode: SessionOrigin.NID_ORIGIN_CODE_FAIL.rawValue, queued: true)
         let allEvents = NeuroID.datastore.getAndRemoveAllQueuedEvents()

--- a/SDKTest/UtilFunctionsTests.swift
+++ b/SDKTest/UtilFunctionsTests.swift
@@ -110,7 +110,7 @@ final class UtilFunctionsTests: XCTestCase {
 
     func test_captureTextEvents_blur() {
         NeuroID.isSDKStarted = true
-        let expectedValue = 1
+        let expectedValue = 0
         let uiView = UIView()
 
         UtilFunctions.captureTextEvents(
@@ -118,8 +118,8 @@ final class UtilFunctionsTests: XCTestCase {
             textValue: textValue,
             eventType: .blur)
 
-        assertEventTypeCount(type: "BLUR", expectedCount: expectedValue)
-        assertEventTypeCount(type: "TEXT_CHANGE", expectedCount: expectedValue)
+        assertEventTypeCount(type: "BLUR", expectedCount: 0)
+        assertEventTypeCount(type: "TEXT_CHANGE", expectedCount: 1)
     }
 
     func test_captureInputTextChangeEvent_input() {

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
@@ -9,6 +9,9 @@ import Foundation
 
 extension NeuroID {
     internal static var deviceSignalService: DeviceSignalService = AdvancedDeviceService()
+    
+    // flag to ensure that we only have one FPJS call in flight
+    internal static var isFPJSRunning = false
 
     public static func start(
         _ advancedDeviceSignals: Bool,
@@ -61,6 +64,12 @@ extension NeuroID {
     }
 
     internal static func getNewADV() {
+        // run one at a time, drop any other instances
+        if (isFPJSRunning == true) {
+            return
+        } else {
+            isFPJSRunning = true
+        }
         deviceSignalService.getAdvancedDeviceSignal(
             NeuroID.clientKey ?? "",
             clientID: NeuroID.clientID,
@@ -78,6 +87,7 @@ extension NeuroID {
                         "key": requestID,
                     ] as [String: Any]
                 )
+                isFPJSRunning = false
             case .failure(let error):
                 NeuroID.saveEventToLocalDataStore(
                     NIDEvent(
@@ -91,6 +101,7 @@ extension NeuroID {
                         m: error.localizedDescription
                     )
                 )
+                isFPJSRunning = false
                 return
             }
         }

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDDataStore.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDDataStore.swift
@@ -8,6 +8,25 @@
 import Foundation
 
 extension NeuroID {
+    
+    static let immediateSendTypes: Set<String> = [
+        NIDEventName.formSubmit.rawValue,
+        NIDEventName.pageSubmit.rawValue,
+        NIDSessionEventName.setLinkedSite.rawValue,
+        NIDEventName.focus.rawValue,
+        NIDSessionEventName.setRegisteredUserId.rawValue,
+        NIDEventName.attemptedLogin.rawValue,
+        NIDSessionEventName.setVariable.rawValue,
+        NIDEventName.applicationMetaData.rawValue,
+        NIDSessionEventName.setUserId.rawValue,
+        NIDEventName.createSession.rawValue,
+        NIDEventName.advancedDevice.rawValue,
+        NIDEventName.advancedDeviceRequestFailed.rawValue,
+        NIDEventName.blur.rawValue,
+        NIDEventName.windowBlur.rawValue,
+        NIDEventName.closeSession.rawValue
+    ]
+    
     /**
         Save and event to the datastore (logic of queue or not contained in this function)
      */
@@ -89,6 +108,11 @@ extension NeuroID {
        NeuroID.logDebug(category: "saveEvent", content: mutableEvent.toDict())
 
         NeuroID.datastore.insertCleanedEvent(event: mutableEvent, storeType: storeType)
+        
+        // send on immediate on certain events
+        if (immediateSendTypes.contains(event.type)) {
+            send()
+        }
    }
     
     static func clearDataStore(){

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDDataStore.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDDataStore.swift
@@ -110,7 +110,7 @@ extension NeuroID {
         NeuroID.datastore.insertCleanedEvent(event: mutableEvent, storeType: storeType)
         
         // send on immediate on certain events
-        if (immediateSendTypes.contains(event.type)) {
+        if (immediateSendTypes.contains(event.type) && isSDKStarted) {
             send()
         }
    }


### PR DESCRIPTION
 Ensure that only one FPJS call is run at any one time

Flush buffer immediately when certain event types are collected.