### PR TITLE
ENG-10135 normalize all versions, commit test plists.

### DIFF
--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -111,6 +111,8 @@ jobs:
           git checkout -b ${{ env.BRANCH_NAME }}
           git status
           set +e
+          git add SDKTest/Info.plist
+          git add SDKUITest/Info.plist
           git add NeuroID.podspec
           git add Source/NeuroID/Info.plist
           git add Source/NeuroID/NIDParamsCreator.swift

--- a/SDKTest/Info.plist
+++ b/SDKTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4.2</string>
+	<string>3.4.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NeuroURL</key>

--- a/SDKUITest/Info.plist
+++ b/SDKUITest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>3.4.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
Need to make versions align properly in all info.list and podspec files, then update the version_update.yml to commit the SDKTest and SDKUITest Info.plist files. 

The fastlane function update_project_version will find all versions in the project from plist and prospec files , take the lowest version and will update all found .plist files in project with CFBundleShortVersionString keys and .podspec files in project with s.version keys to this version number (major, minor, patch) + 1. The fastlane function get_project_version will then search all plist and podspec files and return the lowest version found which is why we need to fix all files to the same version and commit all plist and podspec files to fix the version which should fix the release process. 