### PR TITLE
ENG-10128 add fpjs remote config param

### DIFF
--- a/Source/NeuroID/Models/ConfigModels.swift
+++ b/Source/NeuroID/Models/ConfigModels.swift
@@ -24,7 +24,7 @@ struct ConfigResponseData: Codable {
     var gyroAccelCadence: Bool = false
     var gyroAccelCadenceTime: Int = 200
     var lowMemoryBackOff: Double? = NIDConfigService.DEFAULT_LOW_MEMORY_BACK_OFF
-    var advancedCookieExpiration: Int = 12 * 60 * 60
+    var advancedCookieExpiration: Int? = NIDConfigService.DEFAULT_ADV_COOKIE_EXPIRATION
 
     // could exist for parent site or could be null meaning 100%
     var sampleRate: Int? = NIDConfigService.DEFAULT_SAMPLE_RATE

--- a/Source/NeuroID/Models/ConfigModels.swift
+++ b/Source/NeuroID/Models/ConfigModels.swift
@@ -24,6 +24,7 @@ struct ConfigResponseData: Codable {
     var gyroAccelCadence: Bool = false
     var gyroAccelCadenceTime: Int = 200
     var lowMemoryBackOff: Double? = NIDConfigService.DEFAULT_LOW_MEMORY_BACK_OFF
+    var advancedCookieExpiration: Int = 12 * 60 * 60
 
     // could exist for parent site or could be null meaning 100%
     var sampleRate: Int? = NIDConfigService.DEFAULT_SAMPLE_RATE
@@ -43,5 +44,6 @@ struct ConfigResponseData: Codable {
         case siteID = "site_id"
         case linkedSiteOptions = "linked_site_options"
         case lowMemoryBackOff = "low_memory_back_off"
+        case advancedCookieExpiration = "advanced_cookie_expires"
     }
 }

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
@@ -77,13 +77,13 @@ extension NeuroID {
         ) { request in
             switch request {
             case .success((let requestID, let duration)):
-
+                
                 captureADVEvent(requestID, cached: false, latency: duration)
-
+                
                 setUserDefaultKey(
                     Constants.storageAdvancedDeviceKey.rawValue,
                     value: [
-                        "exp": UtilFunctions.getFutureTimeStamp(24),
+                        "exp": UtilFunctions.getFutureTimeStamp(configService.configCache.advancedCookieExpiration),
                         "key": requestID,
                     ] as [String: Any]
                 )

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
@@ -83,7 +83,7 @@ extension NeuroID {
                 setUserDefaultKey(
                     Constants.storageAdvancedDeviceKey.rawValue,
                     value: [
-                        "exp": UtilFunctions.getFutureTimeStamp(configService.configCache.advancedCookieExpiration),
+                        "exp": UtilFunctions.getFutureTimeStamp(configService.configCache.advancedCookieExpiration ?? NIDConfigService.DEFAULT_ADV_COOKIE_EXPIRATION),
                         "key": requestID,
                     ] as [String: Any]
                 )

--- a/Source/NeuroID/Services/NIDConfigService.swift
+++ b/Source/NeuroID/Services/NIDConfigService.swift
@@ -14,6 +14,7 @@ class NIDConfigService: ConfigServiceProtocol {
     static let DEFAULT_SAMPLE_RATE: Int = 100
     static var NID_CONFIG_URL = "https://scripts.neuro-id.com/mobile/"
     static let DEFAULT_LOW_MEMORY_BACK_OFF = 5.0
+    static let DEFAULT_ADV_COOKIE_EXPIRATION = 12 * 60 * 60
     
     let networkService: NIDNetworkServiceProtocol
     let configRetrievalCallback: () -> Void

--- a/Source/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/Source/NeuroID/TrackerClassExtensions/Utils.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 enum UtilFunctions {
-    static func getFutureTimeStamp(_ hoursToAdd: Int) -> Int {
+    static func getFutureTimeStamp(_ secondsToAdd: Int) -> Int {
         // Get the current time
         let currentTime = Date()
 
@@ -17,7 +17,7 @@ enum UtilFunctions {
         let calendar = Calendar.current
 
         // Add the specified number of hours to the current time
-        if let futureTime = calendar.date(byAdding: .hour, value: hoursToAdd, to: currentTime) {
+        if let futureTime = calendar.date(byAdding: .second, value: secondsToAdd, to: currentTime) {
             return Int(futureTime.timeIntervalSince1970)
         } else {
             return 0


### PR DESCRIPTION
Pull and set FPJS ID cache expiration time from remote config. May need backend change as well to send this data over if not already in the config.

key is expected to be: advanced_cookie_expires and value is expected to be an int. 43200 seconds will be set as default

(NeuroID Debug) Event:  LOG - 1748547789758 - NO_TARGET - m=StartAppFlow attempt with siteID: form_parks912, sessionID:: null
(NeuroID Debug)   Retrieved remote config
(NeuroID Debug) Event:  CONFIG_CACHED - 1748547789813 - NO_TARGET - 


