### PR TITLE
ENG-10214 allow customer to pass in advanced device key.

### DIFF
--- a/SDKTest/Utils/MockDeviceSignalService.swift
+++ b/SDKTest/Utils/MockDeviceSignalService.swift
@@ -10,7 +10,8 @@ import Foundation
 class MockDeviceSignalService: DeviceSignalService {
     var mockResult: Result<(String, Double), Error>?
 
-    func getAdvancedDeviceSignal(_ apiKey: String, clientID: String?, linkedSiteID: String?, completion: @escaping (Result<(String, Double), Error>) -> Void) {
+    func getAdvancedDeviceSignal(_ apiKey: String, clientID: String?, linkedSiteID: String?, advancedDeviceKey: String?,
+                                 completion: @escaping (Result<(String, Double), Error>) -> Void) {
         if let result = mockResult {
             completion(result)
         } else {

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
@@ -54,7 +54,7 @@ extension NeuroID {
                 let currentTimeEpoch = Date().timeIntervalSince1970
 
                 if currentTimeEpoch < exp {
-                    captureADVEvent(requestID, cached: true, latency: 0)
+                    captureADVEvent(requestID, cached: true, latency: 0, message: "")
                     return true
                 }
             }
@@ -73,12 +73,15 @@ extension NeuroID {
         deviceSignalService.getAdvancedDeviceSignal(
             NeuroID.clientKey ?? "",
             clientID: NeuroID.clientID,
-            linkedSiteID: NeuroID.linkedSiteID
+            linkedSiteID: NeuroID.linkedSiteID,
+            advancedDeviceKey: NeuroID.advancedDeviceKey
         ) { request in
             switch request {
             case .success((let requestID, let duration)):
                 
-                captureADVEvent(requestID, cached: false, latency: duration)
+                captureADVEvent(requestID, cached: false,
+                                latency: duration,
+                                message: advancedDeviceKey.isEmptyOrNil ? "server retrieved FPJS key" : "user entered FPJS key")
                 
                 setUserDefaultKey(
                     Constants.storageAdvancedDeviceKey.rawValue,
@@ -108,7 +111,7 @@ extension NeuroID {
     }
 
     internal static func captureADVEvent(
-        _ requestID: String, cached: Bool, latency: Double
+        _ requestID: String, cached: Bool, latency: Double, message: String
     ) {
         NeuroID.saveEventToLocalDataStore(
             NIDEvent(
@@ -116,7 +119,8 @@ extension NeuroID {
                 ct: NeuroID.networkMonitor?.connectionType.rawValue,
                 l: latency,
                 rid: requestID,
-                c: cached
+                c: cached,
+                m: message
             )
         )
     }

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDLog.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDLog.swift
@@ -177,7 +177,7 @@ func NIDPrintEvent(_ mutableEvent: NIDEvent) {
         case NIDEventName.log.rawValue:
             contextString = "m=\(mutableEvent.m ?? "")"
         case NIDEventName.advancedDevice.rawValue:
-        contextString = "rid=\(mutableEvent.rid ?? "") c=\(mutableEvent.c ?? false) l=\(String(describing: mutableEvent.l))"
+        contextString = "rid=\(mutableEvent.rid ?? "") c=\(mutableEvent.c ?? false) l=\(String(describing: mutableEvent.l)) m=\(mutableEvent.m)"
         case NIDEventName.callInProgress.rawValue: contextString = "cp=\(String(describing: mutableEvent.cp ?? nil)) attrs=[\(attrsString)]"
         case NIDEventName.mobileMetadataIOS.rawValue:
             contextString = "latong=\(mutableEvent.metadata?.gpsCoordinates.latitude ?? -1), \(mutableEvent.metadata?.gpsCoordinates.longitude ?? -1)"

--- a/Source/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroID.swift
@@ -19,6 +19,7 @@ import WebKit
 public class NeuroID: NSObject {
     static let SEND_INTERVAL: Double = 5
 
+    static var advancedDeviceKey: String?
     static var clientKey: String?
     static var siteID: String?
     static var linkedSiteID: String?
@@ -90,7 +91,7 @@ public class NeuroID: NSObject {
     /// 1. Configure the SDK
     /// 2. Setup silent running loop
     /// 3. Send cached events from DB every `SEND_INTERVAL`
-    public static func configure(clientKey: String, isAdvancedDevice: Bool = false) -> Bool {
+    public static func configure(clientKey: String, isAdvancedDevice: Bool = false, advancedDeviceKey: String? = nil) -> Bool {
         // set last install time if not already set.
         if (getUserDefaultKeyDouble(Constants.lastInstallTime.rawValue) == 0) {
             setUserDefaultKey(Constants.lastInstallTime.rawValue, value: (Date().timeIntervalSince1970))
@@ -114,7 +115,7 @@ public class NeuroID: NSObject {
 
             return false
         }
-
+        NeuroID.advancedDeviceKey = advancedDeviceKey
         NeuroID.isAdvancedDevice = isAdvancedDevice
 
         if clientKey.contains("_live_") {
@@ -135,6 +136,10 @@ public class NeuroID: NSObject {
 
         networkMonitor = NetworkMonitoringService()
         networkMonitor?.startMonitoring()
+        
+        if (isAdvancedDevice) {
+            captureAdvancedDevice()
+        }
 
         captureApplicationMetaData()
 


### PR DESCRIPTION
Allow customers to pass in advanced device key. 

```
_ = NeuroID.configure(
                    clientKey: "key_live_MwC5DQNYzRsRhnnYjvz1fJtp",
                    isAdvancedDevice: true,
                    advancedDeviceKey: "<some advanced device key>"
                )
```

`(NeuroID Debug) Event:  ADVANCED_DEVICE_REQUEST - 1750813232768 - NO_TARGET - rid=1750813232663.yL2Srz c=false l=Optional(676.6120195388794) m=Optional("user entered FPJS key")`

```
 _ = NeuroID.configure(
                    clientKey: "key_live_MwC5DQNYzRsRhnnYjvz1fJtp",
                    isAdvancedDevice: true
                )
```
`(NeuroID Debug) Event:  ADVANCED_DEVICE_REQUEST - 1750813688784 - NO_TARGET - rid=1750813688673.cewghz c=false l=Optional(668.1679487228394) m=Optional("server retrieved FPJS key")`

