### PR TITLE
ENG-10215 fix empty check, convert empty to nil for proper processing

### DIFF
--- a/Source/NeuroID/Services/AdvancedDeviceService.swift
+++ b/Source/NeuroID/Services/AdvancedDeviceService.swift
@@ -23,7 +23,12 @@ class AdvancedDeviceService: NSObject, DeviceSignalService {
         _ apiKey: String, clientID: String?, linkedSiteID: String?, advancedDeviceKey: String?,
         completion: @escaping (Result<(String, Double), Error>) -> Void
     ) {
-        guard let notNilFPJSKey = advancedDeviceKey else {
+        // normalize empty advanced device keys to nil for use below
+        var advKey = advancedDeviceKey
+        if (advKey != nil && advKey == "") {
+            advKey = nil
+        }
+        guard let notNilFPJSKey = advKey else {
             // FPJS key not passed in, Retrieve Key from NID Server for Request
             AdvancedDeviceService.getAPIKey(
                 apiKey, clientID: clientID, linkedSiteID: linkedSiteID


### PR DESCRIPTION
Currently, if a user enters empty string "" as a advancedDeviceKey parameter, it will be interpreted as a user entered key and the SDK will not retrieve an advanced device key from the server resulting in the advanced device RID call failure. 

To fix this we change empty strings to nil first, then we check for nil and either get the advanced device RID if we have a advanced device key or get the advanced device key from server then get the advanced device RID. Right now in ReactNative iOS and Android, we convert nil values to empty strings before sending them to configure which breaks iOS advanced device. 

iOS native use is working fine as long as users don't fill in the advancedDeviceKey parameter with empty strings.  This fix will allow users to set an empty string in advancedDeviceKey parameters. 
