### PR TITLE
ENG=10215 fix ios build. cannot make release PR, 3.4.6 was removed.

### DIFF
--- a/NeuroID.podspec
+++ b/NeuroID.podspec
@@ -8,7 +8,7 @@ s.name = "NeuroID"
 s.module_name = "NeuroID"
 s.summary = "NeuroID's official SDK for the iOS platform"
 s.requires_arc = true
-s.version = "3.4.6"
+s.version = "3.4.5"
 s.author = { "NeuroID" => "NeuroID" }
 s.homepage = "https://neuro-id.com/"
 

--- a/SDKTest/Info.plist
+++ b/SDKTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4.6</string>
+	<string>3.4.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NeuroURL</key>

--- a/SDKUITest/Info.plist
+++ b/SDKUITest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4.6</string>
+	<string>3.4.5</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Source/NeuroID/Info.plist
+++ b/Source/NeuroID/Info.plist
@@ -15,14 +15,14 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4.6</string>
+	<string>3.4.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NeuroURL</key>
 	<string>https://c52d-148-64-34-107.ngrok.io</string>
-    <key>LSApplicationQueriesSchemes</key>
-    <array>
-    <string>cydia</string>
-    </array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>cydia</string>
+	</array>
 </dict>
 </plist>

--- a/Source/NeuroID/NIDParamsCreator.swift
+++ b/Source/NeuroID/NIDParamsCreator.swift
@@ -184,7 +184,7 @@ enum ParamsCreator {
         if let bundleURL = Bundle(for: NeuroIDTracker.self).url(forResource: "NeuroID", withExtension: "bundle") {
             version = Bundle(url: bundleURL)?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         } else {
-            version = getSPVersionID(version: "%%%3.4.6%%%")
+            version = getSPVersionID(version: "%%%3.4.5%%%")
         }
         return "5.ios\(NeuroID.isRN ? "-rn" : "")-adv-\(version ?? "?")"
     }


### PR DESCRIPTION
Fix iOS build. 

Cannot make release PR. v3.4.6 was removed dues to an error in the release. Removing the v3.4.6 from Github broke the build. Changing the version manually to 3.4.5 should allow the release PR to get built PR build is looking for 3.4.6 which doesn't exist anymore.  