### PR TITLE
ENG-10497 - Update ClientSiteID Tests

### DIFF
--- a/SDKTest/NeuroIDClass/NIDClientSiteIdTests.swift
+++ b/SDKTest/NeuroIDClass/NIDClientSiteIdTests.swift
@@ -9,6 +9,85 @@
 import XCTest
 
 class NIDClientSiteIdTests: BaseTestClass {
+    var neuroID = NeuroID()
+
+    override func setUp() {
+        neuroID = NeuroID()
+    }
+
+    // getClientID
+
+    // user default does not exist and clientID is empty - generate new one
+    func test_getClientID_no_ud_no_cid() {
+        UserDefaults.standard.setValue(nil, forKey: clientIdKey)
+        neuroID.clientID = nil
+
+        let result = neuroID.getClientID()
+
+        assert(result == neuroID.clientID)
+    }
+
+    // user default does not exist and clientID is not empty - use clientID
+    func test_getClientID_no_ud_cid() {
+        let expectedValue = "testID"
+        UserDefaults.standard.setValue(nil, forKey: clientIdKey)
+        neuroID.clientID = expectedValue
+
+        let result = neuroID.getClientID()
+
+        assert(result == expectedValue)
+        assert(result == neuroID.clientID)
+    }
+
+    // user default exists and clientID is empty - use UD
+    func test_getClientID_ud_no_cid() {
+        let expectedValue = "testID"
+        UserDefaults.standard.setValue(expectedValue, forKey: clientIdKey)
+        neuroID.clientID = nil
+
+        let result = neuroID.getClientID()
+
+        assert(result == expectedValue)
+        assert(result != neuroID.clientID)
+        assert(neuroID.clientID == nil)
+    }
+
+    // UD exists and clientID is not empty - use clientID
+    func test_getClientID_ud_cid() {
+        let expectedValue = "testID"
+        UserDefaults.standard.setValue("uid", forKey: clientIdKey)
+        neuroID.clientID = expectedValue
+
+        let result = neuroID.getClientID()
+
+        assert(result == expectedValue)
+        assert(result == neuroID.clientID)
+    }
+
+    // UD exists and clientID is empty BUT UD has _ - generate new one
+    func test_getClientID_bad_ud_no_cid() {
+        let expectedValue = "test_ID"
+        UserDefaults.standard.setValue(expectedValue, forKey: clientIdKey)
+        neuroID.clientID = nil
+
+        let result = neuroID.getClientID()
+
+        assert(result != expectedValue)
+        assert(result == neuroID.clientID)
+    }
+
+    // UD not exist and clientID is not empty BUT has _ - generate new one
+    func test_getClientID_no_ud_bad_cid() {
+        let expectedValue = "test_ID"
+        UserDefaults.standard.setValue(nil, forKey: clientIdKey)
+        neuroID.clientID = expectedValue
+
+        let result = neuroID.getClientID()
+
+        assert(result != expectedValue)
+        assert(result == neuroID.clientID)
+    }
+
     func test_getClientID() {
         UserDefaults.standard.setValue("test-cid", forKey: clientIdKey)
         NeuroID.shared.clientID = nil

--- a/SDKTest/NeuroIDClass/NIDPerformanceTests.swift
+++ b/SDKTest/NeuroIDClass/NIDPerformanceTests.swift
@@ -14,12 +14,12 @@ final class NIDPerformanceTests: XCTestCase {
     let childSiteID = "form_weeee"
 
     override func setUpWithError() throws {
-        mockedConfigService.configCache = ConfigResponseData()
+        mockedConfigService.mockConfigCache = ConfigResponseData()
         NeuroID.shared.configService = mockedConfigService
     }
     
     func test_remote_backoff_overrides_default() {
-        mockedConfigService.configCache.lowMemoryBackOff = 0
+        mockedConfigService.mockConfigCache = ConfigResponseData(lowMemoryBackOff: 0)
         assert(mockedConfigService.configCache.lowMemoryBackOff != NIDConfigService.DEFAULT_LOW_MEMORY_BACK_OFF)
     }
     
@@ -45,7 +45,7 @@ final class NIDPerformanceTests: XCTestCase {
     func testLowMemoryFlagChangesAfterDefaultOverrideToZeroSeconds() {
         NeuroID.shared.lowMemory = false
         
-        mockedConfigService.configCache.lowMemoryBackOff = 0
+        mockedConfigService.mockConfigCache = ConfigResponseData(lowMemoryBackOff: 0)
         
         let expectation = self.expectation(description: "LowMemory flag should be true and then false after 0 seconds")
         

--- a/SDKTest/TestUtils/MockConfigService.swift
+++ b/SDKTest/TestUtils/MockConfigService.swift
@@ -9,10 +9,18 @@ import Foundation
 @testable import NeuroID
 
 class MockConfigService: ConfigServiceProtocol {
-    var configCache: ConfigResponseData = .init()
+    var mockConfigCache: ConfigResponseData = .init()
+
+    func resetMocks() {
+        mockConfigCache = .init()
+    }
+
+    // Protocol Implementation
+    var configCache: ConfigResponseData {
+        mockConfigCache
+    }
 
     func retrieveOrRefreshCache() {}
-
     var siteIDMap: [String: Bool] = [:]
     func clearSiteIDMap() { siteIDMap.removeAll() }
     var isSessionFlowSampled: Bool { return true }

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDClientSiteId.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDClientSiteId.swift
@@ -52,15 +52,6 @@ extension NeuroID {
         return key
     }
 
-    /**
-     Takes an optional string, if the string is nil or matches the cached config siteID then it
-       is the "collection" site meaning the siteID that belongs to the clientKey given
-       in the `configure` command
-     */
-    func isCollectionSite(siteID: String?) -> Bool {
-        return siteID == nil || siteID ?? "" == self.configService.configCache.siteID ?? "noID"
-    }
-
     func addLinkedSiteID(_ siteID: String) {
         if !self.validationService.validateSiteID(siteID) {
             return
@@ -68,7 +59,7 @@ extension NeuroID {
 
         self.linkedSiteID = siteID
 
-        self.saveEventToLocalDataStore(
+        self.eventStorageService.saveEventToLocalDataStore(
             NIDEvent(type: .setLinkedSite, v: siteID)
         )
     }

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDClientSiteId.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDClientSiteId.swift
@@ -13,20 +13,21 @@ extension NeuroID {
      Public user facing getClientID function via Static Instance
      */
     func getClientID() -> String {
-        let clientIdName = Constants.storageClientIDKey.rawValue
-        var cid = getUserDefaultKeyString(clientIdName)
-        if self.clientID != nil {
-            cid = self.clientID
+        if self.clientID != nil, !self.clientID!.contains("_") {
+            return self.clientID!
         }
-        // Ensure we aren't on old client id
-        if cid != nil && !cid!.contains("_") {
-            return cid!
-        } else {
-            cid = ParamsCreator.generateID()
-            self.clientID = cid
-            setUserDefaultKey(clientIdName, value: cid)
-            return cid!
+
+        let storedClientID = getUserDefaultKeyString(Constants.storageClientIDKey.rawValue)
+        if let tempClientID = storedClientID, !tempClientID.contains("_") {
+            // NOTE: This returns the clientID that is stored, but the self.clientID attribute will still be nil
+            return tempClientID
         }
+
+        let newClientID = ParamsCreator.generateID()
+        self.clientID = newClientID
+        setUserDefaultKey(Constants.storageClientIDKey.rawValue, value: newClientID)
+
+        return newClientID
     }
 
     /**


### PR DESCRIPTION
Updated the getClientID tests to validate what was happening today, after I made those tests, I refactored the function so that it was easier to read and follow the logic.

Then I updated the tests for the rest of the functions in the NIDClientSiteID file

I removed the `isCollectionSite` function as it was not being used anywhere. I checked and it was used in the Sampling Service in the latest release but that class has since been deleted and refactored so this was dead code.