### PR TITLE
ENG-10497 - Update RN and Screen Tests

### DIFF
--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -220,9 +220,9 @@ extension NeuroID {
             Attrs(n: "orientation", v: ParamsCreator.getOrientation()),
             Attrs(n: "isRN", v: "\(NeuroID.shared.isRN)"),
         ]
-        NeuroID.shared.saveEventToLocalDataStore(event)
+        self.eventStorageService.saveEventToLocalDataStore(event)
 
-        NeuroID.shared.captureApplicationMetaData()
+        self.captureApplicationMetaData()
     }
 
     func clearSessionVariables() {

--- a/Source/NeuroID/NeuroIDClass/NeuroID.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroID.swift
@@ -314,7 +314,7 @@ public class NeuroID: NSObject {
     func captureApplicationMetaData() {
         let appMetaData = self.getAppMetaData()
 
-        NeuroID.shared.saveEventToDataStore(
+        self.eventStorageService.saveEventToDataStore(
             NIDEvent(
                 type: .applicationMetaData,
                 attrs: [


### PR DESCRIPTION
Updated the RN and Screen tests to be class based and scoped appropriately. 

Additionally updated the `captureMobileMetadata` and `captureApplicationMetaData` functions to use the class instance and service instead of the static one