### PR TITLE
[ENG-10704] Migrate to Swift Testing

### DIFF
--- a/SDKTest/DataStoreTests.swift
+++ b/SDKTest/DataStoreTests.swift
@@ -5,8 +5,10 @@
 //  Created by Clayton Selby on 10/19/21.
 //
 
-@testable import NeuroID
+import Foundation
 import Testing
+
+@testable import NeuroID
 
 @Suite("DataStore Tests")
 class DataStoreTests {

--- a/SDKTest/NeuroIDClass/ConfigurationTests.swift
+++ b/SDKTest/NeuroIDClass/ConfigurationTests.swift
@@ -5,63 +5,50 @@
 //  Created by Collin Dunphy on 11/4/25.
 //
 
-import XCTest
+import Testing
 @testable import NeuroID
 
-class ConfigurationTests: XCTestCase {
-    
-    var config = NeuroID.Configuration(clientKey: "")
-    
-    var neuroID: NeuroID = NeuroID()
-    
-    override func setUp() {
-        super.setUp()
-        neuroID = NeuroID()
-        config = NeuroID.Configuration(
-            clientKey: "test_key",
-            isAdvancedDevice: true
-        )
-    }
+@Suite("Configuration")
+struct ConfigurationTests {
     
     // MARK: - `useAdvancedDeviceProxy` Tests
     
-    // Test that Configuration properly sets the proxy flag
-    func testConfigureWithProxyEnabled() {
-        config.useAdvancedDeviceProxy = true
-        let _ = neuroID.configure(config)
-        
-        XCTAssertTrue(neuroID.useAdvancedDeviceProxy, "Proxy flag should be enabled after configuration")
-    }
-    
-    // Test explicit proxy disabled
-    func testConfigureWithProxyDisabled() {
-        config.useAdvancedDeviceProxy = false
-        let _ = neuroID.configure(config)
-        
-        XCTAssertFalse(neuroID.useAdvancedDeviceProxy, "Proxy flag should be disabled when explicitly set to false")
-    }
+    @Test(
+        "Configuration sets useAdvancedDeviceProxy correctly",
+        arguments: [true, false, nil]
+    )
+    func configureWithProxyEnabled(useProxy: Bool?) {
+        var config = NeuroID.Configuration(
+            clientKey: "test_key",
+            isAdvancedDevice: true
+        )
 
-    // Test default value when not specified
-    func testConfigureProxyDefaultsToFalse() {
-        let _ = neuroID.configure(config)
-        
-        XCTAssertFalse(neuroID.useAdvancedDeviceProxy, "Proxy flag should default to false when not specified")
-    }
-    
-    
-    // Test that the value changes on reconfigure
-    func testReconfigureChangesProxySetting() {
-        // First configure with proxy enabled
-        config.useAdvancedDeviceProxy = true
-        let _ = neuroID.configure(config)
-        
-        XCTAssertTrue(neuroID.useAdvancedDeviceProxy, "Initial configuration should enable proxy")
-        
-        // Reconfigure with proxy disabled
-        config.useAdvancedDeviceProxy = false
-        let _ = neuroID.configure(config)
-        
-        XCTAssertFalse(neuroID.useAdvancedDeviceProxy, "Reconfiguration should disable proxy")
-    }
+        if let useProxy = useProxy {
+            config.useAdvancedDeviceProxy = useProxy
+        }
 
+        let neuroID = NeuroID()
+        _ = neuroID.configure(config)
+
+        #expect(neuroID.useAdvancedDeviceProxy == useProxy ?? false)
+    }
+    
+    @Test("Proxy setting changes on reconfiguration")
+    func reconfigureChangesProxySetting() {
+        let neuroID = NeuroID()
+        var config = NeuroID.Configuration(
+            clientKey: "test_key",
+            isAdvancedDevice: true
+        )
+        
+        // When: First configure with proxy enabled
+        config.useAdvancedDeviceProxy = true
+        _ = neuroID.configure(config)
+        #expect(neuroID.useAdvancedDeviceProxy)
+        
+        // When: Reconfigure with proxy disabled
+        config.useAdvancedDeviceProxy = false
+        _ = neuroID.configure(config)
+        #expect(!neuroID.useAdvancedDeviceProxy)
+    }
 }

--- a/SDKTest/NeuroIDClass/ConfigurationTests.swift
+++ b/SDKTest/NeuroIDClass/ConfigurationTests.swift
@@ -8,7 +8,7 @@
 import Testing
 @testable import NeuroID
 
-@Suite("Configuration")
+@Suite("Configuration Tests")
 struct ConfigurationTests {
     
     // MARK: - `useAdvancedDeviceProxy` Tests

--- a/SDKTest/NeuroIDClass/NIDRNTests.swift
+++ b/SDKTest/NeuroIDClass/NIDRNTests.swift
@@ -6,47 +6,41 @@
 //
 
 @testable import NeuroID
-import XCTest
+import Testing
 
-class NIDRNTests: XCTestCase {
+@Suite("React Native Tests")
+struct NIDRNTests {
     var neuroID = NeuroID()
 
-    override func setUp() {
+    init() {
         neuroID = NeuroID()
         neuroID.isRN = false
     }
 
-    func assertConfigureTests(defaultValue: Bool, expectedValue: Bool) {
-        assert(NeuroID.shared.isRN)
-        let storedValue = NeuroID.shared.rnOptions[.usingReactNavigation] as? Bool ?? defaultValue
-        assert(storedValue == expectedValue)
-        assert(NeuroID.shared.rnOptions.count == 1)
-    }
-
     // setIsRN
-    func test_isRN() {
-        assert(!neuroID.isRN)
+    @Test func isRN() {
+        #expect(!neuroID.isRN)
         neuroID.setIsRN()
 
-        assert(neuroID.isRN)
+        #expect(neuroID.isRN)
     }
 
     // configure
     // configure - clientKey, not advanced, not adv key, not React nav
-    func test_configure_noAdv_noAdvKey_noRNav() {
+    @Test func configure_noAdv_noAdvKey_noRNav() {
         let configured = neuroID.configure(
             clientKey: "key_test_XXXXXXXXXXX",
             rnOptions: [:]
         )
 
-        assert(configured)
-        assert(!neuroID.isAdvancedDevice)
-        assert(neuroID.advancedDeviceKey == "")
-        assert(neuroID.rnOptions[.usingReactNavigation] as! Bool == false)
+        #expect(configured)
+        #expect(!neuroID.isAdvancedDevice)
+        #expect(neuroID.advancedDeviceKey == "")
+        #expect(neuroID.rnOptions[.usingReactNavigation] as! Bool == false)
     }
 
     // configure - client key, advanced, not adv key, not react nav
-    func test_configure_Adv_noAdvKey_noRNav() {
+    @Test func configure_Adv_noAdvKey_noRNav() {
         let configured = neuroID.configure(
             clientKey: "key_test_XXXXXXXXXXX",
             rnOptions: [
@@ -54,14 +48,14 @@ class NIDRNTests: XCTestCase {
             ]
         )
 
-        assert(configured)
-        assert(neuroID.isAdvancedDevice)
-        assert(neuroID.advancedDeviceKey == "")
-        assert(neuroID.rnOptions[.usingReactNavigation] as! Bool == false)
+        #expect(configured)
+        #expect(neuroID.isAdvancedDevice)
+        #expect(neuroID.advancedDeviceKey == "")
+        #expect(neuroID.rnOptions[.usingReactNavigation] as! Bool == false)
     }
 
     // configure - client key, advanced, adv key, not react nav
-    func test_configure_Adv_AdvKey_noRNav() {
+    @Test func configure_Adv_AdvKey_noRNav() {
         let expected = "testKey"
         let configured = neuroID.configure(
             clientKey: "key_test_XXXXXXXXXXX",
@@ -71,14 +65,14 @@ class NIDRNTests: XCTestCase {
             ]
         )
 
-        assert(configured)
-        assert(neuroID.isAdvancedDevice)
-        assert(neuroID.advancedDeviceKey == expected)
-        assert(neuroID.rnOptions[.usingReactNavigation] as! Bool == false)
+        #expect(configured)
+        #expect(neuroID.isAdvancedDevice)
+        #expect(neuroID.advancedDeviceKey == expected)
+        #expect(neuroID.rnOptions[.usingReactNavigation] as! Bool == false)
     }
 
     // configure - client key, advanced, adv key, react nav
-    func test_configure_Adv_AdvKey_RNav() {
+    @Test func configure_Adv_AdvKey_RNav() {
         let expected = "testKey"
         let configured = neuroID.configure(
             clientKey: "key_test_XXXXXXXXXXX",
@@ -89,14 +83,14 @@ class NIDRNTests: XCTestCase {
             ]
         )
 
-        assert(configured)
-        assert(neuroID.isAdvancedDevice)
-        assert(neuroID.advancedDeviceKey == expected)
-        assert(neuroID.rnOptions[.usingReactNavigation] as! Bool == true)
+        #expect(configured)
+        #expect(neuroID.isAdvancedDevice)
+        #expect(neuroID.advancedDeviceKey == expected)
+        #expect(neuroID.rnOptions[.usingReactNavigation] as! Bool == true)
     }
 
     // configure - invalid client key
-    func test_configure_invalid_clientKey() {
+    @Test func configure_invalid_clientKey() {
         let expected = "testKey"
         let configured = neuroID.configure(
             clientKey: "invalidKey",
@@ -107,14 +101,14 @@ class NIDRNTests: XCTestCase {
             ]
         )
 
-        assert(!configured)
-        assert(!neuroID.isAdvancedDevice)
-        assert(neuroID.advancedDeviceKey == nil)
-        assert(neuroID.rnOptions.count == 0)
+        #expect(!configured)
+        #expect(!neuroID.isAdvancedDevice)
+        #expect(neuroID.advancedDeviceKey == nil)
+        #expect(neuroID.rnOptions.count == 0)
     }
 
     // configure - client key, not advanced, not adv key, react nav
-    func test_configure_no_Adv_no_AdvKey_RNav() {
+    @Test func configure_no_Adv_no_AdvKey_RNav() {
         let configured = neuroID.configure(
             clientKey: "key_test_XXXXXXXXXXX",
             rnOptions: [
@@ -122,14 +116,14 @@ class NIDRNTests: XCTestCase {
             ]
         )
 
-        assert(configured)
-        assert(!neuroID.isAdvancedDevice)
-        assert(neuroID.advancedDeviceKey == "")
-        assert(neuroID.rnOptions[.usingReactNavigation] as! Bool == true)
+        #expect(configured)
+        #expect(!neuroID.isAdvancedDevice)
+        #expect(neuroID.advancedDeviceKey == "")
+        #expect(neuroID.rnOptions[.usingReactNavigation] as! Bool == true)
     }
 
     // getOptionValueBool
-    func test_getOptionValueBool_true() {
+    @Test func getOptionValueBool_true() {
         let value = neuroID.getOptionValueBool(
             rnOptions: [
                 RNConfigOptions.usingReactNavigation.rawValue: true,
@@ -138,54 +132,54 @@ class NIDRNTests: XCTestCase {
             configOptionKey: .usingReactNavigation
         )
 
-        assert(value)
+        #expect(value)
     }
 
-    func test_getOptionValueBool_false() {
+    @Test func getOptionValueBool_false() {
         let value = neuroID.getOptionValueBool(
             rnOptions: [RNConfigOptions.usingReactNavigation.rawValue: false],
             configOptionKey: .usingReactNavigation
         )
 
-        assert(!value)
+        #expect(!value)
     }
 
-    func test_getOptionValueBool_invalid() {
+    @Test func getOptionValueBool_invalid() {
         let value = neuroID.getOptionValueBool(
             rnOptions: ["foo": "bar"],
             configOptionKey: .usingReactNavigation
         )
 
-        assert(!value)
+        #expect(!value)
     }
 
     // getOptionValueString
-    func test_getOptionValueString_nonNil() {
+    @Test func getOptionValueString_nonNil() {
         let value = neuroID.getOptionValueString(
             rnOptions: [RNConfigOptions.advancedDeviceKey.rawValue: "testkey"],
             configOptionKey: .advancedDeviceKey
         )
 
-        assert(value == "testkey")
+        #expect(value == "testkey")
     }
 
-    func test_getOptionValueString_nil() {
+    @Test func getOptionValueString_nil() {
         // does not contain advanced device key, therfore nil
         let value = neuroID.getOptionValueString(
             rnOptions: [:],
             configOptionKey: .advancedDeviceKey
         )
 
-        assert(value == "")
+        #expect(value == "")
     }
 
-    func test_getOptionValueString_invalid() {
+    @Test func getOptionValueString_invalid() {
         // does not contain advanced device key, therfore nil
         let value = neuroID.getOptionValueString(
             rnOptions: [RNConfigOptions.advancedDeviceKey.rawValue: false],
             configOptionKey: .advancedDeviceKey
         )
 
-        assert(value == "")
+        #expect(value == "")
     }
 }

--- a/SDKTest/Services/AdvancedDeviceServiceTests.swift
+++ b/SDKTest/Services/AdvancedDeviceServiceTests.swift
@@ -5,32 +5,31 @@
 //  Created by Collin Dunphy on 11/6/25.
 //
 
-import XCTest
-@testable import NeuroID
 import FingerprintPro
+import Testing
 
-class AdvancedDeviceServiceTests: XCTestCase {
-        
-    // MARK: - AdvancedDeviceService endpoint selection
+@testable import NeuroID
 
-    // When `useAdvancedDeviceProxy` is disabled it should select the standard endpoint domain only
+@Suite("Advanced Device Service")
+struct AdvancedDeviceServiceTests {
+
+    @Test("Standard endpoint configuration should match")
     func testEndpointUsesStandardWhenProxyDisabled() {
-        XCTAssertEqual(
-            AdvancedDeviceService.endpoint(useProxy: false),
-            .custom(domain: AdvancedDeviceService.Endpoints.standard.url),
-            "Standard endpoint configuration should match"
+        #expect(
+            AdvancedDeviceService.endpoint(useProxy: false)
+                == .custom(domain: AdvancedDeviceService.Endpoints.standard.url)
         )
     }
 
     // When `useAdvancedDeviceProxy` is enabled it should select the proxy domain with the standard domain as a fallback
+    @Test("Proxy endpoint configuration should match")
     func testEndpointUsesProxyWhenEnabled() {
-        XCTAssertEqual(
-            AdvancedDeviceService.endpoint(useProxy: true),
-            .custom(
-                domain: AdvancedDeviceService.Endpoints.proxy.url,
-                fallback: [AdvancedDeviceService.Endpoints.standard.url]
-            ),
-            "Proxy endpoint configuration should match"
+        #expect(
+            AdvancedDeviceService.endpoint(useProxy: true)
+                == .custom(
+                    domain: AdvancedDeviceService.Endpoints.proxy.url,
+                    fallback: [AdvancedDeviceService.Endpoints.standard.url]
+                )
         )
     }
 }

--- a/SDKTest/Services/ValidationServiceTests.swift
+++ b/SDKTest/Services/ValidationServiceTests.swift
@@ -32,7 +32,6 @@ struct ValidationServiceTests {
             "key_foo_XXXXXXXXXXX",  // invalid
             "sdfsdfsdfsdf",  // random
             "",  // Empty
-            "key_test_ABCDEFGHIG"
         ]
     )
     func validateClientKeyFail(clientKey: String) {

--- a/SDKTest/Services/ValidationServiceTests.swift
+++ b/SDKTest/Services/ValidationServiceTests.swift
@@ -5,71 +5,79 @@
 //  Created by Kevin Sites on 1/27/25.
 //
 
-import Foundation
+import Testing
 @testable import NeuroID
 
-class ValidationServiceTests: BaseTestClass {
+@Suite("Validation Service Tests")
+struct ValidationServiceTests {
     let validationService = ValidationService(
         logger: NIDLog()
     )
 
-    func test_validateClientKey_valid_live() {
-        let value = validationService.validateClientKey("key_live_XXXXXXXXXXX")
-
-        assert(value)
+    // MARK: Client Key
+    @Test(
+        "Validate Site ID - Valid",
+        arguments: [
+            "key_live_XXXXXXXXXXX",  // LIVE
+            "key_test_XXXXXXXXXXX",  // TEST
+        ]
+    )
+    func validateClientKeySuccess(clientKey: String) {
+        #expect(validationService.validateClientKey(clientKey))
     }
 
-    func test_validateClientKey_valid_test() {
-        let value = validationService.validateClientKey("key_test_XXXXXXXXXXX")
-
-        assert(value)
+    @Test(
+        "Validate Site ID - Invalid",
+        arguments: [
+            "key_foo_XXXXXXXXXXX",  // invalid
+            "sdfsdfsdfsdf",  // random
+            "",  // Empty
+            "key_test_ABCDEFGHIG"
+        ]
+    )
+    func validateClientKeyFail(clientKey: String) {
+        #expect(!validationService.validateClientKey(clientKey))
     }
 
-    func test_validateClientKey_invalid_env() {
-        let value = validationService.validateClientKey("key_foo_XXXXXXXXXXX")
-
-        assert(!value)
+    // MARK: Site ID
+    @Test(
+        "Validate Site ID - Valid",
+        arguments: [
+            "form_peaks345"
+        ]
+    )
+    func validateSiteIdSuccess(siteId: String) {
+        #expect(validationService.validateSiteID(siteId))
     }
 
-    func test_validateClientKey_invalid_random() {
-        let value = validationService.validateClientKey("sdfsdfsdfsdf")
-
-        assert(!value)
+    @Test(
+        "Validate Site ID - Invalid",
+        arguments: [
+            "form_abc123",  // too short
+            "badSiteID",  // random
+            "",  // Empty
+        ]
+    )
+    func validateSiteIdFail(siteId: String) {
+        #expect(!validationService.validateSiteID(siteId))
     }
 
-    func test_validateSiteID_valid() {
-        let value = validationService.validateSiteID("form_peaks345")
-
-        assert(value)
-    }
-
-    func test_validateSiteID_invalid_bad() {
-        let value = validationService.validateSiteID("badSiteID")
-
-        assert(!value)
-    }
-
-    func test_validateSiteID_invalid_short() {
-        let value = validationService.validateSiteID("form_abc123")
-
-        assert(!value)
-    }
-
-    func test_validatedIdentifiers_valid_id() {
-        let validIdentifiers = [
+    // MARK: ID
+    @Test(
+        "Validate ID - Valid",
+        arguments: [
             "123",
             "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
             "a-A_1.0",
         ]
-
-        for identifier in validIdentifiers {
-            let userNameSet = validationService.validateIdentifier(identifier)
-            assert(userNameSet == true)
-        }
+    )
+    func validateIdentifierSuccess(id: String) {
+        #expect(validationService.validateIdentifier(id))
     }
 
-    func test_validatedIdentifiers_invalid_id() {
-        let invalidIdentifiers = [
+    @Test(
+        "Validate ID - Invalid",
+        arguments: [
             "",
             "1",
             "12",
@@ -78,12 +86,8 @@ class ValidationServiceTests: BaseTestClass {
             "invalid characters",
             "invalid*ch@racters",
         ]
-
-        for identifier in invalidIdentifiers {
-            let userNameSet = validationService.validateIdentifier(identifier)
-            assert(userNameSet == false)
-        }
+    )
+    func validateIdentifierFail(id: String) {
+        #expect(!validationService.validateIdentifier(id))
     }
-
-//    validateIdentifier
 }

--- a/SDKTest/Utils/BaseClassExtensionTests.swift
+++ b/SDKTest/Utils/BaseClassExtensionTests.swift
@@ -6,10 +6,11 @@
 //
 
 @testable import NeuroID
-import XCTest
+import Testing
 
-class BaseClassExtensionTests: XCTestCase {
-    func test_string_sha256_withSalt() {
+@Suite("Base Class Extensions Tests")
+struct BaseClassExtensionTests {
+    @Test func string_sha256_withSalt() {
         UserDefaults.standard.set("mySalt", forKey: Constants.storageSaltKey.rawValue)
         let og = "myString"
         
@@ -18,7 +19,7 @@ class BaseClassExtensionTests: XCTestCase {
         assert(value == "bbed32651d5c168d7bd222adc04b8b53655ec5db8ca0d4a5ad30a250fcc6c5bc")
     }
     
-    func test_string_sha256_withOutSalt() {
+    @Test func string_sha256_withOutSalt() {
         UserDefaults.standard.set("", forKey: Constants.storageSaltKey.rawValue)
         let og = "myString"
         
@@ -33,7 +34,7 @@ class BaseClassExtensionTests: XCTestCase {
         assert(value == secondValue)
     }
     
-    func test_optional_isEmptyOrNil() {
+    @Test func optional_isEmptyOrNil() {
         let og: String? = "test"
         
         if og.isEmptyOrNil {
@@ -41,7 +42,7 @@ class BaseClassExtensionTests: XCTestCase {
         }
     }
     
-    func test_optional_isEmptyOrNil_nil() {
+    @Test func optional_isEmptyOrNil_nil() {
         let og: String? = nil
         
         if !og.isEmptyOrNil {
@@ -49,7 +50,7 @@ class BaseClassExtensionTests: XCTestCase {
         }
     }
     
-    func test_optional_isEmptyOrNil_empty() {
+    @Test func optional_isEmptyOrNil_empty() {
         let og: String? = ""
         
         if !og.isEmptyOrNil {
@@ -57,7 +58,7 @@ class BaseClassExtensionTests: XCTestCase {
         }
     }
     
-    func test_date_toString() {
+    @Test func date_toString() {
         let og = Date()
         
         let value = og.toString()

--- a/SDKTest/Utils/BaseClassExtensionTests.swift
+++ b/SDKTest/Utils/BaseClassExtensionTests.swift
@@ -5,8 +5,10 @@
 //  Created by Kevin Sites on 8/30/23.
 //
 
-@testable import NeuroID
+import Foundation
 import Testing
+
+@testable import NeuroID
 
 @Suite("Base Class Extensions Tests")
 struct BaseClassExtensionTests {


### PR DESCRIPTION
Updates the following test files to use Swift Testing from XCTest.
- `SDKTest/DataStoreTests.swift`
- `SDKTest/NeuroIDClass/ConfigurationTests.swift`
- `SDKTest/NeuroIDClass/NIDRNTests.swift`
- `SDKTest/Services/AdvancedDeviceServiceTests.swift`
- `SDKTest/Services/ValidationServiceTests.swift`
- `SDKTest/Utils/BaseClassExtensionTests.swift`

[ENG-10704]

[ENG-10704]: https://neuro-id.atlassian.net/browse/ENG-10704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ