### PR TITLE
[ENG-11657] Add testing for Xcode 26.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,10 @@ jobs:
             sonar_check: true
 
           # Legacy
+          - macos: 26
+            xcode: '26.4'   # Swift 6.3
+            ios-simulator: 'iPhone 17 Pro'
+
           - macos: 15
             xcode: '16.4'   # Swift 6.1
             ios-simulator: 'iPhone 16 Pro'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,13 +31,13 @@ jobs:
           
           # Latest
           - macos: 26
-            xcode: '26.0'   # Swift 6.2
+            xcode: '26.4'   # Swift 6.3
             ios-simulator: 'iPhone 17 Pro'
             sonar_check: true
 
           # Legacy
           - macos: 26
-            xcode: '26.4'   # Swift 6.3
+            xcode: '26.2'   # Swift 6.2
             ios-simulator: 'iPhone 17 Pro'
 
           - macos: 15

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: Build and Test (Xcode ${{ matrix.xcode }})
     runs-on: macos-${{ matrix.macos }}
-    timeout-minutes: 45
+    timeout-minutes: 30
     env:
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
     strategy:


### PR DESCRIPTION
Update Swift 6.2 env to Xcode to 26.2. Adds Swift 6.3 env with Xcode 26.4. Also adjusts testing timeout to 30 min.

[ENG-11657]

[ENG-11657]: https://neuro-id.atlassian.net/browse/ENG-11657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ