### PR TITLE
[ENG-11697] Update: screen recording to use `sceneCaptureState`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,16 +39,16 @@ jobs:
           - macos: 26
             xcode: '26.2'   # Swift 6.2
             ios-simulator: 'iPhone 17 Pro'
-            ios-version: 'latest'
+            ios-version: '26.2'
 
           - macos: 15
             xcode: '16.4'   # Swift 6.1
             ios-simulator: 'iPhone 16 Pro'
-            ios-version: '18.0'
+            ios-version: '18.6'
 
           - macos: 14
             xcode: '16.2'   # Swift 6.0
-            ios-simulator: 'iPhone 16 Pro'
+            ios-simulator: 'iPhone 15 Pro'
             ios-version: '17.0'
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           - macos: 14
             xcode: '16.2'   # Swift 6.0
             ios-simulator: 'iPhone 15 Pro'
-            ios-version: '17.0'
+            ios-version: '17.5'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,42 +79,22 @@ jobs:
             -resultBundlePath TestResults.xcresult | \
           xcbeautify --renderer github-actions
 
+      - name: Convert Coverage for Sonar
+        if: ${{ matrix.sonar_check == true }}
+        run: ./Scripts/xccov-to-sonarqube-generic.sh TestResults.xcresult > Coverage.xml
+
       - name: Upload test results
         uses: actions/upload-artifact@v5
-        if: always() # Still upload results even if the build or tests fail
+        if: always()
         with:
-          name: xcode-test-results-macos-${{ matrix.macos }}-xcode-${{ matrix.xcode }}.xcresult
-          path: TestResults.xcresult
-          if-no-files-found: ignore
-
-  sonar:
-    name: Sonar Analysis
-    needs: build
-    runs-on: macos-26
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode_26.4.app"
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # Full history for accurate Sonar analysis
-
-      - name: Select Xcode Version
-        run: sudo xcode-select -s ${{ env.DEVELOPER_DIR }}
-
-      - name: Download all test results
-        uses: actions/download-artifact@v4
-        with:
-          pattern: xcode-test-results-*
-          path: test-results
-          merge-multiple: false
-
-      - name: Merge coverage reports
-        run: xcrun xccov merge $(find test-results -maxdepth 2 -name "*.xcresult" -type d) --outReport MergedResults.xcresult
-
-      - name: Convert Coverage for Sonar
-        run: ./Scripts/xccov-to-sonarqube-generic.sh MergedResults.xcresult > Coverage.xml
+          name: xcode-test-results-macos-${{ matrix.macos }}-xcode-${{ matrix.xcode }}
+          path: |
+            TestResults.xcresult
+            Coverage.xml 
+          if-no-files-found: ignore # Coverage.xml wil not exist for older builds
 
       - name: Sonar Scan
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
+        if: ${{ matrix.sonar_check == true }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
             xcode: '26.4'   # Swift 6.3
             ios-simulator: 'iPhone 17 Pro'
             ios-version: 'latest'
+            sonar_check: true
 
           # Legacy
           - macos: 26

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,19 +33,23 @@ jobs:
           - macos: 26
             xcode: '26.4'   # Swift 6.3
             ios-simulator: 'iPhone 17 Pro'
+            ios-version: 'latest'
 
           # Legacy
           - macos: 26
             xcode: '26.2'   # Swift 6.2
             ios-simulator: 'iPhone 17 Pro'
+            ios-version: 'latest'
 
           - macos: 15
             xcode: '16.4'   # Swift 6.1
             ios-simulator: 'iPhone 16 Pro'
+            ios-version: '18.0'
 
           - macos: 14
             xcode: '16.2'   # Swift 6.0
             ios-simulator: 'iPhone 16 Pro'
+            ios-version: '17.0'
 
     steps:
       - uses: actions/checkout@v6
@@ -70,7 +74,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             -project NeuroID.xcodeproj \
             -scheme NeuroID \
-            -destination "platform=iOS Simulator,name=${{ matrix.ios-simulator }}" \
+            -destination "platform=iOS Simulator,name=${{ matrix.ios-simulator }},OS=${{ matrix.ios-version }}" \
             -configuration Debug \
             -resultBundlePath TestResults.xcresult | \
           xcbeautify --renderer github-actions
@@ -79,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v5
         if: always() # Still upload results even if the build or tests fail
         with:
-          name: xcode-test-results-macos-${{ matrix.macos }}-xcode-${{ matrix.xcode }}
+          name: xcode-test-results-macos-${{ matrix.macos }}-xcode-${{ matrix.xcode }}.xcresult
           path: TestResults.xcresult
           if-no-files-found: ignore
 
@@ -102,11 +106,10 @@ jobs:
         with:
           pattern: xcode-test-results-*
           path: test-results
+          merge-multiple: false
 
       - name: Merge coverage reports
-        run: |
-          mapfile -t xcresults < <(find test-results -maxdepth 2 -name "*.xcresult" -type d)
-          xcrun xccov merge "${xcresults[@]}" --outReport MergedResults.xcresult
+        run: xcrun xccov merge $(find test-results -maxdepth 2 -name "*.xcresult" -type d) --outReport MergedResults.xcresult
 
       - name: Convert Coverage for Sonar
         run: ./Scripts/xccov-to-sonarqube-generic.sh MergedResults.xcresult > Coverage.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
           - macos: 26
             xcode: '26.4'   # Swift 6.3
             ios-simulator: 'iPhone 17 Pro'
-            sonar_check: true
 
           # Legacy
           - macos: 26
@@ -76,22 +75,43 @@ jobs:
             -resultBundlePath TestResults.xcresult | \
           xcbeautify --renderer github-actions
 
-      - name: Convert Coverage for Sonar
-        if: ${{ matrix.sonar_check == true }}
-        run: ./Scripts/xccov-to-sonarqube-generic.sh TestResults.xcresult > Coverage.xml
-
       - name: Upload test results
         uses: actions/upload-artifact@v5
-        if: always()
+        if: always() # Still upload results even if the build or tests fail
         with:
           name: xcode-test-results-macos-${{ matrix.macos }}-xcode-${{ matrix.xcode }}
-          path: |
-            TestResults.xcresult
-            Coverage.xml 
-          if-no-files-found: ignore # Coverage.xml wil not exist for older builds
+          path: TestResults.xcresult
+          if-no-files-found: ignore
+
+  sonar:
+    name: Sonar Analysis
+    needs: build
+    runs-on: macos-26
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_26.4.app"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Full history for accurate Sonar analysis
+
+      - name: Select Xcode Version
+        run: sudo xcode-select -s ${{ env.DEVELOPER_DIR }}
+
+      - name: Download all test results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: xcode-test-results-*
+          path: test-results
+
+      - name: Merge coverage reports
+        run: |
+          mapfile -t xcresults < <(find test-results -maxdepth 2 -name "*.xcresult" -type d)
+          xcrun xccov merge "${xcresults[@]}" --outReport MergedResults.xcresult
+
+      - name: Convert Coverage for Sonar
+        run: ./Scripts/xccov-to-sonarqube-generic.sh MergedResults.xcresult > Coverage.xml
 
       - name: Sonar Scan
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
-        if: ${{ matrix.sonar_check == true }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/SDKTest/BaseTestClass.swift
+++ b/SDKTest/BaseTestClass.swift
@@ -9,6 +9,7 @@ import XCTest
 
 @testable import NeuroID
 
+@MainActor
 class BaseTestClass: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
 

--- a/SDKTest/NIDEventTests.swift
+++ b/SDKTest/NIDEventTests.swift
@@ -8,6 +8,7 @@
 @testable import NeuroID
 import XCTest
 
+@MainActor
 class NIDEventTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
     let userId = "form_mobilesandbox"

--- a/SDKTest/NIDEventTests.swift
+++ b/SDKTest/NIDEventTests.swift
@@ -171,7 +171,6 @@ class NIDEventTests: XCTestCase {
         } catch {
             NIDLog.error("\(error.localizedDescription)")
         }
-        assert(neuroHTTPRequest != nil)
     }
     
     func test_init_1() {

--- a/SDKTest/NeuroIDClass/NIDPerformanceTests.swift
+++ b/SDKTest/NeuroIDClass/NIDPerformanceTests.swift
@@ -8,6 +8,7 @@
 @testable import NeuroID
 import XCTest
 
+@MainActor
 final class NIDPerformanceTests: XCTestCase {
     let mockedConfigService = MockConfigService()
     

--- a/SDKTest/NeuroIDTrackerTests.swift
+++ b/SDKTest/NeuroIDTrackerTests.swift
@@ -238,17 +238,20 @@ class NeuroIDTrackerTests: BaseTestClass {
         assert(events.count == 1)
     }
     
-    func test_clearSessionVariablesClearsScreenCaptureState() {
-        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["scene"] = NSObject()
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["scene"] = true
+    func test_screenCapture() {
+        let tracker = NeuroIDTracker(screen: screenNameValue, controller: nil)
+        tracker.screenCapture()
         
-        NeuroIDCore.shared.screenCaptureLastKnownState = true
+        let events = assertEventTypeCount(type: NIDEventName.screenCapture.rawValue, expectedCount: 1)
+        XCTAssertEqual(events.first?.type, NIDEventName.screenCapture.rawValue)
+    }
+    
+    func test_screenRecording() {
+        let tracker = NeuroIDTracker(screen: screenNameValue, controller: nil)
+        tracker.screenRecording()
         
-        NeuroIDCore.shared.clearSessionVariables()
-        
-        XCTAssertTrue(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.isEmpty)
-        XCTAssertTrue(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.isEmpty)
-        XCTAssertNil(NeuroIDCore.shared.screenCaptureLastKnownState)
+        let events = assertEventTypeCount(type: NIDEventName.screenRecording.rawValue, expectedCount: 1)
+        XCTAssertEqual(events.first?.type, NIDEventName.screenRecording.rawValue)
     }
 
 //    func test_subscribe() {

--- a/SDKTest/NeuroIDTrackerTests.swift
+++ b/SDKTest/NeuroIDTrackerTests.swift
@@ -237,22 +237,6 @@ class NeuroIDTrackerTests: BaseTestClass {
         let events = NeuroIDCore.shared.datastore.getAllEvents().filter { $0.type == "REGISTER_TARGET" }
         assert(events.count == 1)
     }
-    
-    func test_screenCapture() {
-        let tracker = NeuroIDTracker(screen: screenNameValue, controller: nil)
-        tracker.screenCapture()
-        
-        let events = assertEventTypeCount(type: NIDEventName.screenCapture.rawValue, expectedCount: 1)
-        XCTAssertEqual(events.first?.type, NIDEventName.screenCapture.rawValue)
-    }
-    
-    func test_screenRecording() {
-        let tracker = NeuroIDTracker(screen: screenNameValue, controller: nil)
-        tracker.screenRecording()
-        
-        let events = assertEventTypeCount(type: NIDEventName.screenRecording.rawValue, expectedCount: 1)
-        XCTAssertEqual(events.first?.type, NIDEventName.screenRecording.rawValue)
-    }
 
 //    func test_subscribe() {
 //        NeuroID.observingInputs = false

--- a/SDKTest/NeuroIDTrackerTests.swift
+++ b/SDKTest/NeuroIDTrackerTests.swift
@@ -238,20 +238,17 @@ class NeuroIDTrackerTests: BaseTestClass {
         assert(events.count == 1)
     }
     
-    func test_screenCapture() {
-        let tracker = NeuroIDTracker(screen: screenNameValue, controller: nil)
-        tracker.screenCapture()
+    func test_clearSessionVariablesClearsScreenCaptureState() {
+        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["scene"] = NSObject()
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["scene"] = true
         
-        let events = assertEventTypeCount(type: NIDEventName.screenCapture.rawValue, expectedCount: 1)
-        XCTAssertEqual(events.first?.type, NIDEventName.screenCapture.rawValue)
-    }
-    
-    func test_screenRecording() {
-        let tracker = NeuroIDTracker(screen: screenNameValue, controller: nil)
-        tracker.screenRecording()
+        NeuroIDCore.shared.screenCaptureLastKnownState = true
         
-        let events = assertEventTypeCount(type: NIDEventName.screenRecording.rawValue, expectedCount: 1)
-        XCTAssertEqual(events.first?.type, NIDEventName.screenRecording.rawValue)
+        NeuroIDCore.shared.clearSessionVariables()
+        
+        XCTAssertTrue(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.isEmpty)
+        XCTAssertTrue(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.isEmpty)
+        XCTAssertNil(NeuroIDCore.shared.screenCaptureLastKnownState)
     }
 
 //    func test_subscribe() {

--- a/SDKTest/Services/ListenerManagerServiceTests.swift
+++ b/SDKTest/Services/ListenerManagerServiceTests.swift
@@ -20,29 +20,13 @@ struct ListenerManagerServiceTests {
         self.notificationCenter = NotificationCenter()
         self.listenerManagerService = ListenerManagerService(notificationCenter: notificationCenter)
         NeuroIDCore.shared._isSDKStarted = true
+        NeuroIDCore.shared.screenCaptureLastKnownState = nil
         
         self.dataStore = DataStore()
         NeuroIDCore.shared.datastore = dataStore
     }
     
-    @Test
-    @MainActor
-    func updateScreenRecordingStateIfChanged() {
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
-     
-        let events = dataStore.getAllEvents()
-        
-        #expect(
-            events.map(\.type) == [
-                NIDEventName.screenRecordingStarted.rawValue,
-                NIDEventName.screenRecordingStopped.rawValue
-            ]
-        )
-        
-        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
-    }
+    // MARK: - Screenshot
     
     @Test
     @MainActor
@@ -61,33 +45,10 @@ struct ListenerManagerServiceTests {
         #expect(screenshotEvents.count == 1)
     }
     
-    @Test
-    @MainActor
-    func screenRecordingStartStopTwice() {
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
-     
-        let events = dataStore.getAllEvents()
-        
-        #expect(
-            events.map(\.type) == [
-                NIDEventName.screenRecordingStarted.rawValue,
-                NIDEventName.screenRecordingStopped.rawValue,
-                NIDEventName.screenRecordingStarted.rawValue,
-                NIDEventName.screenRecordingStopped.rawValue
-            ]
-        )
-        
-        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
-    }
-    
-    // Make sure listeners are removed succesfully
+    // Make sure listeners are removed successfully
     @Test(arguments: [true, false])
     @MainActor
     func stopAppEventListenersRemovesObserver(shouldStart: Bool) {
-
         if shouldStart {
             listenerManagerService.startAppEventListeners()
         }
@@ -103,6 +64,65 @@ struct ListenerManagerServiceTests {
         #expect(screenshotEvents.isEmpty)
     }
     
+    // MARK: - Screen Recording
+    
+    /// First call with isActive=true sets baseline and emits an active event.
+    /// Duplicate call with same state is ignored.
+    /// State change to false emits an inactive event.
+    @Test
+    @MainActor
+    func updateScreenRecordingStateIfChanged() {
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)  // duplicate — ignored
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
+     
+        let events = dataStore.getAllEvents().filter {
+            $0.type == NIDEventName.screenRecording.rawValue
+        }
+        
+        #expect(events.count == 2)
+        #expect(events[0].attrs == [Attrs(n: "state", v: "active")])
+        #expect(events[1].attrs == [Attrs(n: "state", v: "inactive")])
+        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
+    }
+    
+    /// First call with isActive=false sets baseline but emits no event (not capturing).
+    @Test
+    @MainActor
+    func updateScreenRecordingStateIfChanged_initialInactive_noEvent() {
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
+        
+        let events = dataStore.getAllEvents().filter {
+            $0.type == NIDEventName.screenRecording.rawValue
+        }
+        
+        #expect(events.isEmpty)
+        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
+    }
+    
+    /// Multiple start/stop cycles each emit an event.
+    @Test
+    @MainActor
+    func screenRecordingStartStopTwice() {
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
+     
+        let events = dataStore.getAllEvents().filter {
+            $0.type == NIDEventName.screenRecording.rawValue
+        }
+        
+        #expect(events.count == 4)
+        #expect(events[0].attrs == [Attrs(n: "state", v: "active")])
+        #expect(events[1].attrs == [Attrs(n: "state", v: "inactive")])
+        #expect(events[2].attrs == [Attrs(n: "state", v: "active")])
+        #expect(events[3].attrs == [Attrs(n: "state", v: "inactive")])
+        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
+    }
+    
+    // MARK: - iOS 17 Scene-based Recording
+    
     @available(iOS 17.0, *)
     @Test
     @MainActor
@@ -115,7 +135,11 @@ struct ListenerManagerServiceTests {
         
         #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.isEmpty)
         #expect(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.isEmpty)
-        #expect(dataStore.getAllEvents().last?.type == NIDEventName.screenRecordingStopped.rawValue)
+        
+        // After disconnect the aggregate is false → emits inactive event
+        let lastEvent = dataStore.getAllEvents().last
+        #expect(lastEvent?.type == NIDEventName.screenRecording.rawValue)
+        #expect(lastEvent?.attrs == [Attrs(n: "state", v: "inactive")])
     }
     
     @available(iOS 17.0, *)
@@ -136,7 +160,8 @@ struct ListenerManagerServiceTests {
             listenerManagerService.observeSceneCaptureEvents(inScreen: controller)
             #expect(
                 dataStore.getAllEvents().filter {
-                    $0.type == NIDEventName.screenRecordingStarted.rawValue
+                    $0.type == NIDEventName.screenRecording.rawValue &&
+                    $0.attrs == [Attrs(n: "state", v: "active")]
                 }.isEmpty
             )
         }

--- a/SDKTest/Services/ListenerManagerServiceTests.swift
+++ b/SDKTest/Services/ListenerManagerServiceTests.swift
@@ -3,15 +3,15 @@
 //  NeuroID
 //
 
-import UIKit
 import Testing
+import UIKit
 
 @testable import NeuroID
 
 @Suite
 @MainActor
 struct ListenerManagerServiceTests {
-    
+
     var notificationCenter: NotificationCenter
     var listenerManagerService: ListenerManagerService
     var dataStore: DataStore
@@ -19,151 +19,176 @@ struct ListenerManagerServiceTests {
     init() {
         self.notificationCenter = NotificationCenter()
         self.listenerManagerService = ListenerManagerService(notificationCenter: notificationCenter)
-        NeuroIDCore.shared._isSDKStarted = true
-        NeuroIDCore.shared.screenCaptureLastKnownState = nil
-        
         self.dataStore = DataStore()
+        NeuroIDCore.shared._isSDKStarted = true
         NeuroIDCore.shared.datastore = dataStore
+        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeAll()
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeAll()
+        NeuroIDCore.shared.screenCaptureLastKnownState = nil
     }
-    
-    // MARK: - Screenshot
-    
+
+    func screenRecordingEvents() -> [NIDEvent] {
+        dataStore.getAllEvents().filter { $0.type == NIDEventName.screenRecording.rawValue }
+    }
+
+    @available(iOS 17.0, *)
+    func connectedWindowScenes() -> [UIWindowScene] {
+        UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+    }
+
     @Test
-    @MainActor
-    func startAppEventListeners_screenshotObserverRegisteredOnce() {
+    func startAppEventListeners_screenshotObserverRegisteredOnce() async {
         listenerManagerService.startAppEventListeners()
         listenerManagerService.startAppEventListeners()
         listenerManagerService.startAppEventListeners()
-        
-        // Send screenshot notification
         notificationCenter.post(name: UIApplication.userDidTakeScreenshotNotification, object: nil)
-        
+        await Task.yield()
         let screenshotEvents = dataStore.getAllEvents().filter {
             $0.type == NIDEventName.screenCapture.rawValue
         }
-        
         #expect(screenshotEvents.count == 1)
     }
-    
-    // Make sure listeners are removed successfully
-    @Test(arguments: [true, false])
-    @MainActor
-    func stopAppEventListenersRemovesObserver(shouldStart: Bool) {
-        if shouldStart {
-            listenerManagerService.startAppEventListeners()
-        }
-        listenerManagerService.stopAppEventListeners()
-        
-        // Send screenshot notification
-        notificationCenter.post(name: UIApplication.userDidTakeScreenshotNotification, object: nil)
 
+    @Test
+    func stopAppEventListeners_removesObservers() async {
+        listenerManagerService.startAppEventListeners()
+        listenerManagerService.stopAppEventListeners()
+        notificationCenter.post(name: UIApplication.userDidTakeScreenshotNotification, object: nil)
+        await Task.yield()
         let screenshotEvents = dataStore.getAllEvents().filter {
             $0.type == NIDEventName.screenCapture.rawValue
         }
-        
         #expect(screenshotEvents.isEmpty)
     }
-    
-    // MARK: - Screen Recording
-    
-    /// First call with isActive=true sets baseline and emits an active event.
-    /// Duplicate call with same state is ignored.
-    /// State change to false emits an inactive event.
+
     @Test
-    @MainActor
-    func updateScreenRecordingStateIfChanged() {
+    func stopAppEventListeners_clearsScreenCaptureTrackingState() {
+        listenerManagerService.startAppEventListeners()
+        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["scene"] = NSObject()
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["scene"] = true
+        NeuroIDCore.shared.screenCaptureLastKnownState = true
+        listenerManagerService.stopAppEventListeners()
+        #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.isEmpty)
+        #expect(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.isEmpty)
+        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == nil)
+    }
+
+    @Test
+    func updateScreenRecordingStateIfChanged_emitsActiveAndInactiveOnTransitions() {
         listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)  // duplicate — ignored
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
         listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
-     
-        let events = dataStore.getAllEvents().filter {
-            $0.type == NIDEventName.screenRecording.rawValue
-        }
-        
+        let events = screenRecordingEvents()
         #expect(events.count == 2)
         #expect(events[0].attrs == [Attrs(n: "state", v: "active")])
         #expect(events[1].attrs == [Attrs(n: "state", v: "inactive")])
         #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
     }
-    
-    /// First call with isActive=false sets baseline but emits no event (not capturing).
+
     @Test
-    @MainActor
-    func updateScreenRecordingStateIfChanged_initialInactive_noEvent() {
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
-        
-        let events = dataStore.getAllEvents().filter {
-            $0.type == NIDEventName.screenRecording.rawValue
-        }
-        
-        #expect(events.isEmpty)
-        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
-    }
-    
-    /// Multiple start/stop cycles each emit an event.
-    @Test
-    @MainActor
-    func screenRecordingStartStopTwice() {
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
-        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
-     
-        let events = dataStore.getAllEvents().filter {
-            $0.type == NIDEventName.screenRecording.rawValue
-        }
-        
-        #expect(events.count == 4)
+    func handleLegacyScreenCaptureChange_updatesRecordingState() {
+        listenerManagerService.handleLegacyScreenCaptureChange(isCaptured: false)
+        listenerManagerService.handleLegacyScreenCaptureChange(isCaptured: true)
+        listenerManagerService.handleLegacyScreenCaptureChange(isCaptured: false)
+        let events = screenRecordingEvents()
+        #expect(events.count == 2)
         #expect(events[0].attrs == [Attrs(n: "state", v: "active")])
         #expect(events[1].attrs == [Attrs(n: "state", v: "inactive")])
-        #expect(events[2].attrs == [Attrs(n: "state", v: "active")])
-        #expect(events[3].attrs == [Attrs(n: "state", v: "inactive")])
         #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
     }
-    
-    // MARK: - iOS 17 Scene-based Recording
-    
+
+    @Test
+    func startLegacyScreenRecordingObserver_observesCapturedDidChange() async {
+        listenerManagerService.startLegacyScreenRecordingObserver()
+        notificationCenter.post(name: UIScreen.capturedDidChangeNotification, object: UIScreen.main)
+        await Task.yield()
+        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == UIScreen.main.isCaptured)
+    }
+
     @available(iOS 17.0, *)
     @Test
-    @MainActor
-    func sceneDisconnectUpdatesAggregateState() {
+    func registerSceneIfNeeded_registersConnectedSceneState() {
+        let scenes = connectedWindowScenes()
+        guard let scene = scenes.first else { return }
+        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeAll()
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeAll()
+        listenerManagerService.registerSceneIfNeeded(scene)
+        let sceneID = scene.session.persistentIdentifier
+        #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] != nil)
+        #expect(
+            NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID]
+                == (scene.traitCollection.sceneCaptureState == .active)
+        )
+    }
+
+    @available(iOS 17.0, *)
+    @Test
+    func registerExistingScenes_registersEachConnectedScene() {
+        let scenes = connectedWindowScenes()
+        guard !scenes.isEmpty else { return }
+        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeAll()
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeAll()
+        listenerManagerService.registerExistingScenes()
+        for scene in scenes {
+            let sceneID = scene.session.persistentIdentifier
+            #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] != nil)
+            #expect(
+                NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID]
+                    == (scene.traitCollection.sceneCaptureState == .active)
+            )
+        }
+    }
+
+    @available(iOS 17.0, *)
+    @Test
+    func handleSceneDidActivate_registersSceneIfNeeded() {
+        let scenes = connectedWindowScenes()
+        guard let scene = scenes.first else { return }
+        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeAll()
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeAll()
+        listenerManagerService.handleSceneDidActivate(scene)
+        let sceneID = scene.session.persistentIdentifier
+        #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] != nil)
+        #expect(
+            NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID]
+                == (scene.traitCollection.sceneCaptureState == .active)
+        )
+    }
+
+    @available(iOS 17.0, *)
+    @Test
+    func handleSceneCaptureTraitChange_updatesAggregateAndEmitsInactive() {
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneA"] = true
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneB"] = false
+        NeuroIDCore.shared.screenCaptureLastKnownState = true
+        listenerManagerService.handleSceneCaptureTraitChange(sceneID: "sceneA", isActive: false)
+        #expect(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneA"] == false)
+        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
+        #expect(screenRecordingEvents().last?.attrs == [Attrs(n: "state", v: "inactive")])
+    }
+
+    @available(iOS 17.0, *)
+    @Test
+    func sceneDidDisconnect_removesSceneAndRefreshesAggregate() {
         NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["sceneA"] = NSObject()
         NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneA"] = true
         NeuroIDCore.shared.screenCaptureLastKnownState = true
-        
         listenerManagerService.sceneDidDisconnect(sceneID: "sceneA")
-        
-        #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.isEmpty)
-        #expect(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.isEmpty)
-        
-        // After disconnect the aggregate is false → emits inactive event
-        let lastEvent = dataStore.getAllEvents().last
-        #expect(lastEvent?.type == NIDEventName.screenRecording.rawValue)
-        #expect(lastEvent?.attrs == [Attrs(n: "state", v: "inactive")])
+        #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["sceneA"] == nil)
+        #expect(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneA"] == nil)
+        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
+        #expect(screenRecordingEvents().last?.attrs == [Attrs(n: "state", v: "inactive")])
     }
-    
+
     @available(iOS 17.0, *)
     @Test
-    @MainActor
-    func observeSceneCaptureEvents_whenAlreadyRegistered_doesNotReEmitRecordingState() throws {
-        withKnownIssue {
-            let scene = try #require(UIApplication.shared.connectedScenes.first as? UIWindowScene)
-            
-            let window = UIWindow(windowScene: scene)
-            let controller = UIViewController()
-            window.rootViewController = controller
-            window.makeKeyAndVisible()
-            let sceneID = scene.session.persistentIdentifier
-            NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = NSObject()
-            NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = true
-            NeuroIDCore.shared.screenCaptureLastKnownState = true
-            listenerManagerService.observeSceneCaptureEvents(inScreen: controller)
-            #expect(
-                dataStore.getAllEvents().filter {
-                    $0.type == NIDEventName.screenRecording.rawValue &&
-                    $0.attrs == [Attrs(n: "state", v: "active")]
-                }.isEmpty
-            )
-        }
+    func handleSceneDidDisconnect_routesToSceneDisconnectFlow() {
+        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["sceneB"] = NSObject()
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneB"] = true
+        NeuroIDCore.shared.screenCaptureLastKnownState = true
+        listenerManagerService.handleSceneDidDisconnect(sceneID: "sceneB")
+        #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["sceneB"] == nil)
+        #expect(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneB"] == nil)
+        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
     }
 }

--- a/SDKTest/Services/ListenerManagerServiceTests.swift
+++ b/SDKTest/Services/ListenerManagerServiceTests.swift
@@ -1,0 +1,117 @@
+//
+//  ListenerManagerServiceTests.swift
+//  NeuroID
+//
+
+import UIKit
+import Testing
+
+@testable import NeuroID
+
+@Suite
+@MainActor
+struct ListenerManagerServiceTests {
+    
+    var notificationCenter: NotificationCenter
+    var listenerManagerService: ListenerManagerService
+    var dataStore: DataStore
+
+    init() {
+        self.notificationCenter = NotificationCenter()
+        self.listenerManagerService = ListenerManagerService(notificationCenter: notificationCenter)
+        NeuroIDCore.shared._isSDKStarted = true
+        
+        self.dataStore = DataStore()
+        NeuroIDCore.shared.datastore = dataStore
+    }
+    
+    @Test
+    @MainActor
+    func updateScreenRecordingStateIfChanged() {
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
+     
+        let events = dataStore.getAllEvents()
+        
+        #expect(
+            events.map(\.type) == [
+                NIDEventName.screenRecordingStarted.rawValue,
+                NIDEventName.screenRecordingStopped.rawValue
+            ]
+        )
+        
+        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
+    }
+    
+    @Test
+    @MainActor
+    func startAppEventListeners_screenshotObserverRegisteredOnce() {
+        listenerManagerService.startAppEventListeners()
+        listenerManagerService.startAppEventListeners()
+        listenerManagerService.startAppEventListeners()
+        
+        // Send screenshot notification
+        notificationCenter.post(name: UIApplication.userDidTakeScreenshotNotification, object: nil)
+        
+        let screenshotEvents = dataStore.getAllEvents().filter {
+            $0.type == NIDEventName.screenCapture.rawValue
+        }
+        
+        #expect(screenshotEvents.count == 1)
+    }
+    
+    @Test
+    @MainActor
+    func stopAppEventListenersRemovesObserver() {
+
+        listenerManagerService.startAppEventListeners()
+        listenerManagerService.stopAppEventListeners()
+        
+        // Send screenshot notification
+        notificationCenter.post(name: UIApplication.userDidTakeScreenshotNotification, object: nil)
+
+        let screenshotEvents = dataStore.getAllEvents().filter {
+            $0.type == NIDEventName.screenCapture.rawValue
+        }
+        
+        #expect(screenshotEvents.isEmpty)
+    }
+    
+    @available(iOS 17.0, *)
+    @Test
+    @MainActor
+    func sceneDisconnectUpdatesAggregateState() {
+        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["sceneA"] = NSObject()
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneA"] = true
+        NeuroIDCore.shared.screenCaptureLastKnownState = true
+        
+        listenerManagerService.sceneDidDisconnect(sceneID: "sceneA")
+        
+        #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.isEmpty)
+        #expect(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.isEmpty)
+        #expect(dataStore.getAllEvents().last?.type == NIDEventName.screenRecordingStopped.rawValue)
+    }
+    
+    @available(iOS 17.0, *)
+    @Test
+    @MainActor
+    func observeSceneCaptureEvents_whenAlreadyRegistered_doesNotReEmitRecordingState() {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+
+        let window = UIWindow(windowScene: scene)
+        let controller = UIViewController()
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        let sceneID = String(ObjectIdentifier(scene).hashValue)
+        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = NSObject()
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = true
+        NeuroIDCore.shared.screenCaptureLastKnownState = true
+        listenerManagerService.observeSceneCaptureEvents(inScreen: controller)
+        #expect(
+            dataStore.getAllEvents().filter {
+                $0.type == NIDEventName.screenRecordingStarted.rawValue
+            }.isEmpty
+        )
+    }
+}

--- a/SDKTest/Services/ListenerManagerServiceTests.swift
+++ b/SDKTest/Services/ListenerManagerServiceTests.swift
@@ -63,9 +63,34 @@ struct ListenerManagerServiceTests {
     
     @Test
     @MainActor
-    func stopAppEventListenersRemovesObserver() {
+    func screenRecordingStartStopTwice() {
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
+     
+        let events = dataStore.getAllEvents()
+        
+        #expect(
+            events.map(\.type) == [
+                NIDEventName.screenRecordingStarted.rawValue,
+                NIDEventName.screenRecordingStopped.rawValue,
+                NIDEventName.screenRecordingStarted.rawValue,
+                NIDEventName.screenRecordingStopped.rawValue
+            ]
+        )
+        
+        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
+    }
+    
+    // Make sure listeners are removed succesfully
+    @Test(arguments: [true, false])
+    @MainActor
+    func stopAppEventListenersRemovesObserver(shouldStart: Bool) {
 
-        listenerManagerService.startAppEventListeners()
+        if shouldStart {
+            listenerManagerService.startAppEventListeners()
+        }
         listenerManagerService.stopAppEventListeners()
         
         // Send screenshot notification
@@ -96,22 +121,24 @@ struct ListenerManagerServiceTests {
     @available(iOS 17.0, *)
     @Test
     @MainActor
-    func observeSceneCaptureEvents_whenAlreadyRegistered_doesNotReEmitRecordingState() {
-        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
-
-        let window = UIWindow(windowScene: scene)
-        let controller = UIViewController()
-        window.rootViewController = controller
-        window.makeKeyAndVisible()
-        let sceneID = String(ObjectIdentifier(scene).hashValue)
-        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = NSObject()
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = true
-        NeuroIDCore.shared.screenCaptureLastKnownState = true
-        listenerManagerService.observeSceneCaptureEvents(inScreen: controller)
-        #expect(
-            dataStore.getAllEvents().filter {
-                $0.type == NIDEventName.screenRecordingStarted.rawValue
-            }.isEmpty
-        )
+    func observeSceneCaptureEvents_whenAlreadyRegistered_doesNotReEmitRecordingState() throws {
+        withKnownIssue {
+            let scene = try #require(UIApplication.shared.connectedScenes.first as? UIWindowScene)
+            
+            let window = UIWindow(windowScene: scene)
+            let controller = UIViewController()
+            window.rootViewController = controller
+            window.makeKeyAndVisible()
+            let sceneID = scene.session.persistentIdentifier
+            NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = NSObject()
+            NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = true
+            NeuroIDCore.shared.screenCaptureLastKnownState = true
+            listenerManagerService.observeSceneCaptureEvents(inScreen: controller)
+            #expect(
+                dataStore.getAllEvents().filter {
+                    $0.type == NIDEventName.screenRecordingStarted.rawValue
+                }.isEmpty
+            )
+        }
     }
 }

--- a/SDKTest/Utils/SessionTests.swift
+++ b/SDKTest/Utils/SessionTests.swift
@@ -8,6 +8,7 @@
 @testable import NeuroID
 import XCTest
 
+@MainActor
 class SessionTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
 

--- a/Source/NeuroID/Models/NIDEvent.swift
+++ b/Source/NeuroID/Models/NIDEvent.swift
@@ -51,8 +51,7 @@ enum NIDEventName: String {
     case deviceMotion = "DEVICE_MOTION"
     case deviceOrientation = "DEVICE_ORIENTATION"
     case screenCapture = "SCREEN_CAPTURE"
-    case screenRecordingStarted = "SCREEN_RECORDING_STARTED"
-    case screenRecordingStopped = "SCREEN_RECORDING_STOPPED"
+    case screenRecording = "SCREEN_RECORDING"
 
     case customTouchStart = "CUSTOM_TOUCH_START"
     case customTouchEnd = "CUSTOM_TOUCH_END"

--- a/Source/NeuroID/Models/NIDEvent.swift
+++ b/Source/NeuroID/Models/NIDEvent.swift
@@ -51,7 +51,8 @@ enum NIDEventName: String {
     case deviceMotion = "DEVICE_MOTION"
     case deviceOrientation = "DEVICE_ORIENTATION"
     case screenCapture = "SCREEN_CAPTURE"
-    case screenRecording = "SCREEN_RECORDING"
+    case screenRecordingStarted = "SCREEN_RECORDING_STARTED"
+    case screenRecordingStopped = "SCREEN_RECORDING_STOPPED"
 
     case customTouchStart = "CUSTOM_TOUCH_START"
     case customTouchEnd = "CUSTOM_TOUCH_END"
@@ -437,7 +438,7 @@ public class NIDEvent: Codable {
         self.isconnected = isconnected
         self.sealedClientResults = sealedClientResults
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case type
         case tg

--- a/Source/NeuroID/NIDParamsCreator.swift
+++ b/Source/NeuroID/NIDParamsCreator.swift
@@ -25,8 +25,7 @@ enum ParamsCreator {
     }
 
     static func getTimeStamp() -> Int64 {
-        let now = Int64(Date().timeIntervalSince1970 * 1000)
-        return now
+        return Int64(Date().timeIntervalSince1970 * 1000)
     }
 
     static func getTGParamsForInput(
@@ -140,13 +139,7 @@ enum ParamsCreator {
     }
 
     static func getDnt() -> Bool {
-        let dnt = getUserDefaultKeyString(Constants.storageDntKey.rawValue)
-        // If there is ANYTHING set in nid_dnt, we return true (meaning don't track)
-        if dnt != nil {
-            return true
-        } else {
-            return false
-        }
+        return getUserDefaultKeyString(Constants.storageDntKey.rawValue) != nil
     }
 
     // Obviously, being a phone we always support touch
@@ -168,8 +161,7 @@ enum ParamsCreator {
 
     // Minutes from GMT
     static func getTimezone() -> Int {
-        let timezone = TimeZone.current.secondsFromGMT() / 60
-        return timezone
+        return TimeZone.current.secondsFromGMT() / 60
     }
 
     static func getLanguage() -> String {

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -227,6 +227,7 @@ extension NeuroIDCore {
         identifierService.clearIDs()
 
         linkedSiteID = nil
+        clearSceneCaptureTracking()
     }
 
     func pauseCollection(flushEventQueue: Bool = false) {

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -227,7 +227,6 @@ extension NeuroIDCore {
         identifierService.clearIDs()
 
         linkedSiteID = nil
-        clearSceneCaptureTracking()
     }
 
     func pauseCollection(flushEventQueue: Bool = false) {

--- a/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
@@ -33,7 +33,7 @@ class NeuroIDCore: NSObject {
 
     var callObserver: CallStatusObserverServiceProtocol?
     var locationManager: LocationManagerServiceProtocol?
-    var listenerManager: ListenerManagerService?
+    var listenerManager: ListenerManagerService
 
     // flag to ensure that we only have one FPJS call in flight
     var isFPJSRunning = false
@@ -159,7 +159,7 @@ class NeuroIDCore: NSObject {
             )
         self.callObserver = callObserver
         self.locationManager = locationManager
-        self.listenerManager = listenerManager ?? ListenerManagerService()
+        self.listenerManager = listenerManager ?? ListenerManagerService(notificationCenter: .default)
 
         self.sendCollectionEventsJob = RepeatingTask(
             interval: Double(self.configService.configCache.eventQueueFlushInterval),

--- a/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
@@ -33,6 +33,7 @@ class NeuroIDCore: NSObject {
 
     var callObserver: CallStatusObserverServiceProtocol?
     var locationManager: LocationManagerServiceProtocol?
+    var listenerManager: ListenerManagerService?
 
     // flag to ensure that we only have one FPJS call in flight
     var isFPJSRunning = false
@@ -109,6 +110,7 @@ class NeuroIDCore: NSObject {
 
     var sceneCaptureRegistrationsBySceneID: [String: AnyObject] = [:]
     var sceneCaptureLastKnownStateBySceneID: [String: Bool] = [:]
+    var screenCaptureLastKnownState: Bool?
 
     var packetNumber: Int32 = 0
 
@@ -128,7 +130,8 @@ class NeuroIDCore: NSObject {
         deviceSignalService: AdvancedDeviceServiceProtocol? = nil,
         payloadSendingService: PayloadSendingServiceProtocol? = nil,
         callObserver: CallStatusObserverServiceProtocol? = nil,
-        locationManager: LocationManagerServiceProtocol? = nil
+        locationManager: LocationManagerServiceProtocol? = nil,
+        listenerManager: ListenerManagerService? = nil
     ) {
         self.datastore = datastore ?? DataStore()
         self.eventStorageService = eventStorageService ?? EventStorageService()
@@ -156,6 +159,7 @@ class NeuroIDCore: NSObject {
             )
         self.callObserver = callObserver
         self.locationManager = locationManager
+        self.listenerManager = listenerManager ?? ListenerManagerService()
 
         self.sendCollectionEventsJob = RepeatingTask(
             interval: Double(self.configService.configCache.eventQueueFlushInterval),
@@ -281,6 +285,12 @@ class NeuroIDCore: NSObject {
 
     func isStopped() -> Bool {
         return self._isSDKStarted != true
+    }
+    
+    func clearSceneCaptureTracking() {
+        self.sceneCaptureLastKnownStateBySceneID.removeAll()
+        self.sceneCaptureRegistrationsBySceneID.removeAll()
+        self.screenCaptureLastKnownState = nil
     }
 
     func swizzle() {

--- a/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
@@ -286,12 +286,6 @@ class NeuroIDCore: NSObject {
     func isStopped() -> Bool {
         return self._isSDKStarted != true
     }
-    
-    func clearSceneCaptureTracking() {
-        self.sceneCaptureLastKnownStateBySceneID.removeAll()
-        self.sceneCaptureRegistrationsBySceneID.removeAll()
-        self.screenCaptureLastKnownState = nil
-    }
 
     func swizzle() {
         if self.didSwizzle {

--- a/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
@@ -107,6 +107,9 @@ class NeuroIDCore: NSObject {
 
     var lowMemory: Bool = false
 
+    var sceneCaptureRegistrationsBySceneID: [String: AnyObject] = [:]
+    var sceneCaptureLastKnownStateBySceneID: [String: Bool] = [:]
+
     var packetNumber: Int32 = 0
 
     // Testing Purposes Only

--- a/Source/NeuroID/NeuroIDTracker.swift
+++ b/Source/NeuroID/NeuroIDTracker.swift
@@ -13,7 +13,6 @@ class NeuroIDTracker: NSObject {
     private var screen: String?
     private var nidClassName: String?
     private var createSessionEvent: NIDEvent?
-    var appEventObservers: [NSObjectProtocol] = []
 
     /// Capture letter count of textfield/textview to detect a paste action
     var textCapturing = [String: String]()
@@ -230,6 +229,7 @@ class NeuroIDTracker: NSObject {
 }
 
 extension NeuroIDTracker {
+    @MainActor
     func subscribe(inScreen controller: UIViewController?) {
         // Early exit if we are stopped
         if NeuroID.isStopped() {
@@ -240,7 +240,8 @@ extension NeuroIDTracker {
             observeViews(views)
         }
 
-        observeSceneCaptureEvents(inScreen: controller)
+        NeuroIDCore.shared.listenerManager?.observeSceneCaptureEvents(inScreen: controller)
+        NeuroIDCore.shared.listenerManager?.startAppEventListeners()
 
         // Only run observations on first run
         if !NeuroIDCore.shared.observingInputs {
@@ -251,6 +252,7 @@ extension NeuroIDTracker {
         }
     }
 
+    @MainActor
     func observeViews(_ views: [UIView]) {
         for v in views {
             if let sender = v as? UIControl {

--- a/Source/NeuroID/NeuroIDTracker.swift
+++ b/Source/NeuroID/NeuroIDTracker.swift
@@ -240,7 +240,6 @@ extension NeuroIDTracker {
             observeViews(views)
         }
 
-        NeuroIDCore.shared.listenerManager.observeSceneCaptureEvents(inScreen: controller)
         NeuroIDCore.shared.listenerManager.startAppEventListeners()
 
         // Only run observations on first run

--- a/Source/NeuroID/NeuroIDTracker.swift
+++ b/Source/NeuroID/NeuroIDTracker.swift
@@ -240,8 +240,8 @@ extension NeuroIDTracker {
             observeViews(views)
         }
 
-        NeuroIDCore.shared.listenerManager?.observeSceneCaptureEvents(inScreen: controller)
-        NeuroIDCore.shared.listenerManager?.startAppEventListeners()
+        NeuroIDCore.shared.listenerManager.observeSceneCaptureEvents(inScreen: controller)
+        NeuroIDCore.shared.listenerManager.startAppEventListeners()
 
         // Only run observations on first run
         if !NeuroIDCore.shared.observingInputs {

--- a/Source/NeuroID/NeuroIDTracker.swift
+++ b/Source/NeuroID/NeuroIDTracker.swift
@@ -1,19 +1,20 @@
 import CommonCrypto
 import Foundation
 import ObjectiveC
-import os
 import SwiftUI
 import UIKit
 import WebKit
+import os
 
 // MARK: - NeuroIDTracker
 
+@MainActor
 class NeuroIDTracker: NSObject {
     private var screen: String?
     private var nidClassName: String?
     private var createSessionEvent: NIDEvent?
     var appEventObservers: [NSObjectProtocol] = []
-    
+
     /// Capture letter count of textfield/textview to detect a paste action
     var textCapturing = [String: String]()
     public init(screen: String, controller: UIViewController?) {
@@ -25,11 +26,6 @@ class NeuroIDTracker: NSObject {
         nidClassName = controller?.nidClassName
     }
 
-    deinit {
-        appEventObservers.forEach { NotificationCenter.default.removeObserver($0) }
-        appEventObservers.removeAll()
-    }
-
     public func captureEvent(event: NIDEvent) {
         let screenName = screen ?? ParamsCreator.generateID()
         let newEvent = event
@@ -37,7 +33,7 @@ class NeuroIDTracker: NSObject {
         newEvent.url = NeuroID.getScreenName()
         NeuroIDCore.shared.saveEventToLocalDataStore(newEvent, screen: screenName)
     }
-    
+
     public static func registerSingleView(
         v: Any,
         screenName: String,
@@ -46,27 +42,27 @@ class NeuroIDTracker: NSObject {
         topDownHierarchyPath: String
     ) {
         let currView = v as? UIView
-        
+
         // constants
         let screenName = NeuroID.getScreenName() ?? screenName
         let bottomUpHierarchyPath = UtilFunctions.getFullViewlURLPath(currView: currView ?? UIView())
-        
+
         let baseAttrs = [
             Attrs(n: "\(Constants.attrGuidKey.rawValue)", v: guid),
             Attrs(n: "\(Constants.attrScreenHierarchyKey.rawValue)", v: bottomUpHierarchyPath),
-            Attrs(n: "top-\(Constants.attrScreenHierarchyKey.rawValue)", v: topDownHierarchyPath),
+            Attrs(n: "top-\(Constants.attrScreenHierarchyKey.rawValue)", v: topDownHierarchyPath)
         ]
-        
+
         let tg = [
             "\(Constants.attrKey.rawValue)": TargetValue.attr(
                 [
                     Attr(n: "\(Constants.attrScreenHierarchyKey.rawValue)", v: bottomUpHierarchyPath),
                     Attr(n: "\(Constants.attrGuidKey.rawValue)", v: guid),
-                    Attr(n: "top-\(Constants.attrScreenHierarchyKey.rawValue)", v: topDownHierarchyPath),
+                    Attr(n: "top-\(Constants.attrScreenHierarchyKey.rawValue)", v: topDownHierarchyPath)
                 ]
-            ),
+            )
         ]
-        
+
         // variables per view type
         var value = ""
         var etn = "INPUT"
@@ -75,7 +71,7 @@ class NeuroIDTracker: NSObject {
         var type = ""
         var extraAttrs: [Attrs] = []
         var rawText = false
-        
+
         // indicate if a supported element was found
         var found = false
 
@@ -214,12 +210,12 @@ class NeuroIDTracker: NSObject {
         // Inputs
         // Checkbox/Radios inputs
     }
-    
+
     static func registerViewIfNotRegistered(view: UIView) -> Bool {
         if !NeuroIDCore.registeredTargets.contains(view.id) {
             NeuroIDCore.registeredTargets.append(view.id)
             let guid = ParamsCreator.generateID()
-            
+
             NeuroIDTracker.registerSingleView(
                 v: view,
                 screenName: NeuroID.getScreenName() ?? view.nidClassName,
@@ -243,6 +239,8 @@ extension NeuroIDTracker {
         if let views = controller?.viewIfLoaded?.subviews {
             observeViews(views)
         }
+
+        observeSceneCaptureEvents(inScreen: controller)
 
         // Only run observations on first run
         if !NeuroIDCore.shared.observingInputs {

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -16,45 +16,56 @@ protocol ListenerManagerServiceProtocol {
 }
 
 final class ListenerManagerService: ListenerManagerServiceProtocol {
-    private var appEventObservers: [NSObjectProtocol] = []
-
+    
+    let notificationCenter: NotificationCenter
+    private var appEventObservers: [NSObjectProtocol]
+    
+    init(notificationCenter: NotificationCenter) {
+        self.notificationCenter = notificationCenter
+        self.appEventObservers = []
+    }
+    
+    // Attach listeners to notification center events
     @MainActor
     func startAppEventListeners() {
         guard appEventObservers.isEmpty else { return }
 
-        // Screenshot Observer
+        // Screen Capture (screenshot) Observer
         appEventObservers.append(
-            NotificationCenter.default.addObserver(
+            notificationCenter.addObserver(
                 forName: UIApplication.userDidTakeScreenshotNotification,
                 object: nil,
                 queue: .main
-            ) { [weak self] _ in
-                self?.captureEvent(event: .screenCapture)
+            ) { message in
+                ListenerManagerService.captureEvent(event: .screenCapture)
             }
         )
 
         // Screen Recording Events for <iOS 17.0
         if #unavailable(iOS 17.0) {
             appEventObservers.append(
-                NotificationCenter.default.addObserver(
+                notificationCenter.addObserver(
                     forName: UIScreen.capturedDidChangeNotification,
                     object: UIScreen.main,
                     queue: .main
-                ) { [weak self] _ in
-                    self?.updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
+                ) { message in
+                    self.updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
                 }
             )
 
             updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
-        } else {
+        }
+        
+        // Handles scene disconnects for iOS 17.0+
+        if #available(iOS 17.0, *) {
             appEventObservers.append(
-                NotificationCenter.default.addObserver(
+                notificationCenter.addObserver(
                     forName: UIScene.didDisconnectNotification,
                     object: nil,
                     queue: .main
-                ) { [weak self] notification in
+                ) { notification in
                     guard let scene = notification.object as? UIScene else { return }
-                    self?.sceneDidDisconnect(sceneID: scene.session.persistentIdentifier)
+                    self.sceneDidDisconnect(sceneID: scene.session.persistentIdentifier)
                 }
             )
             performInitialSceneCaptureCheck()
@@ -64,10 +75,11 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
     @MainActor
     func stopAppEventListeners() {
         guard !appEventObservers.isEmpty else { return }
-        appEventObservers.forEach { NotificationCenter.default.removeObserver($0) }
+        appEventObservers.forEach { notificationCenter.removeObserver($0) }
         appEventObservers.removeAll()
     }
 
+    // Start observing events at the view controller
     @MainActor
     func observeSceneCaptureEvents(inScreen controller: UIViewController?) {
         guard #available(iOS 17.0, *), let scene = controller?.viewIfLoaded?.window?.windowScene else { return }
@@ -92,14 +104,14 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
         if NeuroIDCore.shared.screenCaptureLastKnownState == nil {
             NeuroIDCore.shared.screenCaptureLastKnownState = isActive
             if isActive {
-                captureEvent(event: .screenRecordingStarted)
+                ListenerManagerService.captureEvent(event: .screenRecordingStarted)
             }
             return
         }
 
         guard NeuroIDCore.shared.screenCaptureLastKnownState != isActive else { return }
         NeuroIDCore.shared.screenCaptureLastKnownState = isActive
-        captureEvent(event: isActive ? .screenRecordingStarted : .screenRecordingStopped)
+        ListenerManagerService.captureEvent(event: isActive ? .screenRecordingStarted : .screenRecordingStopped)
     }
 
     @available(iOS 17.0, *)
@@ -122,6 +134,7 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
     }
     
     @available(iOS 17.0, *)
+    @MainActor
     func performInitialSceneCaptureCheck() {
         let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
         for scene in scenes {
@@ -132,7 +145,8 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
         refreshSceneAggregateRecordingState()
     }
 
-    private func captureEvent(event: NIDEventName) {
+    
+    private static func captureEvent(event: NIDEventName) {
         let event = NIDEvent(type: event, url: NeuroID.getScreenName())
         NeuroIDCore.shared.saveEventToLocalDataStore(event, screen: NeuroID.getScreenName() ?? ParamsCreator.generateID())
     }

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -43,7 +43,9 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
     func stopAppEventListeners() {
         guard !appEventObservers.isEmpty else { return }
 
-        appEventObservers.forEach { notificationCenter.removeObserver($0) }
+        for observer in appEventObservers {
+            notificationCenter.removeObserver(observer)
+        }
         appEventObservers.removeAll()
 
         NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeAll()

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -29,10 +29,13 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
         startSceneLifecycleObservers()
 
         if #available(iOS 17.0, *) {
+            // UIScreen.capturedDidChangeNotification is deprecated in iOS 17+, replaced by per-scene trait callbacks
+            // connected scenes won't fire didActivate, so seed their state before computing the initial aggregate
             registerExistingScenes()
             refreshSceneAggregateRecordingState()
         } else {
             startLegacyScreenRecordingObserver()
+            // notification won't fire if recording was already active when the SDK starts
             updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
         }
     }
@@ -66,6 +69,7 @@ extension ListenerManagerService {
     }
 
     func startSceneLifecycleObservers() {
+        // also fires on foreground return, catching scenes not present at SDK start
         appEventObservers.append(
             notificationCenter.addObserver(
                 forName: UIScene.didActivateNotification,
@@ -79,6 +83,7 @@ extension ListenerManagerService {
             }
         )
 
+        // prevents stale scene entries from holding aggregate state as "active"
         appEventObservers.append(
             notificationCenter.addObserver(
                 forName: UIScene.didDisconnectNotification,
@@ -141,6 +146,7 @@ extension ListenerManagerService {
         let sceneID = scene.session.persistentIdentifier
         guard NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] == nil else { return }
         NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = scene.traitCollection.sceneCaptureState == .active
+        // iOS 17+ replacement for the deprecated traitCollectionDidChange override
         let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) {
             [weak self] (windowScene: UIWindowScene, _: UITraitCollection) in
             let changedSceneID = windowScene.session.persistentIdentifier
@@ -173,6 +179,7 @@ extension ListenerManagerService {
     func updateScreenRecordingStateIfChanged(isActive: Bool) {
         let event = NIDEvent(type: .screenRecording)
         if NeuroIDCore.shared.screenCaptureLastKnownState == nil {
+            // first observation — only emit if already active to avoid a spurious "inactive" on cold start
             NeuroIDCore.shared.screenCaptureLastKnownState = isActive
             if isActive {
                 event.attrs = [Attrs(n: "state", v: "active")]
@@ -180,6 +187,7 @@ extension ListenerManagerService {
             }
             return
         }
+        // dedupe — multiple scenes can converge on the same state
         guard NeuroIDCore.shared.screenCaptureLastKnownState != isActive else { return }
         NeuroIDCore.shared.screenCaptureLastKnownState = isActive
         event.attrs = [Attrs(n: "state", v: isActive ? "active" : "inactive")]
@@ -188,6 +196,7 @@ extension ListenerManagerService {
 
     @available(iOS 17.0, *)
     func refreshSceneAggregateRecordingState() {
+        // any one scene capturing = device is recording
         let isActive = NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.values.contains(true)
         updateScreenRecordingStateIfChanged(isActive: isActive)
     }

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -37,7 +37,7 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
                 object: nil,
                 queue: .main
             ) { message in
-                ListenerManagerService.captureEvent(event: .screenCapture)
+                ListenerManagerService.captureEvent(event: NIDEvent(type: .screenCapture))
             }
         )
 
@@ -86,8 +86,8 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
         appEventObservers.removeAll()
     }
 
-    private static func captureEvent(event: NIDEventName) {
-        let event = NIDEvent(type: event, url: NeuroID.getScreenName())
+    private static func captureEvent(event: NIDEvent) {
+        event.url = NeuroID.getScreenName()
         NeuroIDCore.shared.saveEventToLocalDataStore(event, screen: NeuroID.getScreenName() ?? ParamsCreator.generateID())
     }
 }
@@ -106,8 +106,7 @@ extension ListenerManagerService {
             NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = scene.traitCollection.sceneCaptureState == .active
 
             let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) { (windowScene: UIWindowScene, previousTraitCollection: UITraitCollection) in
-                NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[windowScene.session.persistentIdentifier] =
-                    windowScene.traitCollection.sceneCaptureState == .active
+                NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[windowScene.session.persistentIdentifier] = windowScene.traitCollection.sceneCaptureState == .active
                 self.refreshSceneAggregateRecordingState()
             }
             NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = registration as AnyObject
@@ -116,17 +115,21 @@ extension ListenerManagerService {
 
     func updateScreenRecordingStateIfChanged(isActive: Bool) {
         //If there was no known state, set a baseline
+        let event = NIDEvent(type: .screenRecording)
         if NeuroIDCore.shared.screenCaptureLastKnownState == nil {
             NeuroIDCore.shared.screenCaptureLastKnownState = isActive
             if isActive {
-                ListenerManagerService.captureEvent(event: .screenRecordingStarted)
+                event.attrs = [Attrs(n: "state", v: "active")]
+                ListenerManagerService.captureEvent(event: event)
             }
             return
         }
 
         guard NeuroIDCore.shared.screenCaptureLastKnownState != isActive else { return }
         NeuroIDCore.shared.screenCaptureLastKnownState = isActive
-        ListenerManagerService.captureEvent(event: isActive ? .screenRecordingStarted : .screenRecordingStopped)
+
+        event.attrs = [Attrs(n: "state", v: isActive ? "active" : "inactive")]
+        ListenerManagerService.captureEvent(event: event)
     }
 
     @available(iOS 17.0, *)

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -53,6 +53,7 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
                 }
             )
 
+            // Initial check to see if the screen is observed
             updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
         }
         
@@ -68,7 +69,13 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
                     self.sceneDidDisconnect(sceneID: scene.session.persistentIdentifier)
                 }
             )
-            performInitialSceneCaptureCheck()
+
+            // Initial capture check across all connected scenes
+            for scene in UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }) {
+                NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[scene.session.persistentIdentifier] =
+                    scene.traitCollection.sceneCaptureState == .active
+            }
+            refreshSceneAggregateRecordingState()
         }
     }
 
@@ -91,10 +98,9 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
 
             let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) {
                 [weak self] (windowScene: UIWindowScene, previousTraitCollection: UITraitCollection) in
-                self?.updateSceneCaptureState(
-                    sceneID: windowScene.session.persistentIdentifier,
-                    isActive: windowScene.traitCollection.sceneCaptureState == .active
-                )
+                NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[windowScene.session.persistentIdentifier] =
+                    windowScene.traitCollection.sceneCaptureState == .active
+                self?.refreshSceneAggregateRecordingState()
             }
             NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = registration as AnyObject
         }
@@ -115,12 +121,6 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
     }
 
     @available(iOS 17.0, *)
-    private func updateSceneCaptureState(sceneID: String, isActive: Bool) {
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = isActive
-        refreshSceneAggregateRecordingState()
-    }
-
-    @available(iOS 17.0, *)
     func sceneDidDisconnect(sceneID: String) {
         NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeValue(forKey: sceneID)
         NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeValue(forKey: sceneID)
@@ -132,20 +132,7 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
         let isActive = NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.values.contains(true)
         updateScreenRecordingStateIfChanged(isActive: isActive)
     }
-    
-    @available(iOS 17.0, *)
-    @MainActor
-    func performInitialSceneCaptureCheck() {
-        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
-        for scene in scenes {
-            let sceneID = scene.session.persistentIdentifier
-            NeuroIDCore.shared
-                .sceneCaptureLastKnownStateBySceneID[sceneID] = scene.traitCollection.sceneCaptureState == .active
-        }
-        refreshSceneAggregateRecordingState()
-    }
 
-    
     private static func captureEvent(event: NIDEventName) {
         let event = NIDEvent(type: event, url: NeuroID.getScreenName())
         NeuroIDCore.shared.saveEventToLocalDataStore(event, screen: NeuroID.getScreenName() ?? ParamsCreator.generateID())

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -86,6 +86,15 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
         appEventObservers.removeAll()
     }
 
+    private static func captureEvent(event: NIDEventName) {
+        let event = NIDEvent(type: event, url: NeuroID.getScreenName())
+        NeuroIDCore.shared.saveEventToLocalDataStore(event, screen: NeuroID.getScreenName() ?? ParamsCreator.generateID())
+    }
+}
+
+// Screen Recording Logic
+extension ListenerManagerService {
+
     // Start observing events at the view controller
     @MainActor
     func observeSceneCaptureEvents(inScreen controller: UIViewController?) {
@@ -96,17 +105,17 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
         if NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] == nil {
             NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = scene.traitCollection.sceneCaptureState == .active
 
-            let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) {
-                [weak self] (windowScene: UIWindowScene, previousTraitCollection: UITraitCollection) in
+            let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) { (windowScene: UIWindowScene, previousTraitCollection: UITraitCollection) in
                 NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[windowScene.session.persistentIdentifier] =
                     windowScene.traitCollection.sceneCaptureState == .active
-                self?.refreshSceneAggregateRecordingState()
+                self.refreshSceneAggregateRecordingState()
             }
             NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = registration as AnyObject
         }
     }
 
     func updateScreenRecordingStateIfChanged(isActive: Bool) {
+        //If there was no known state, set a baseline
         if NeuroIDCore.shared.screenCaptureLastKnownState == nil {
             NeuroIDCore.shared.screenCaptureLastKnownState = isActive
             if isActive {
@@ -131,10 +140,5 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
     func refreshSceneAggregateRecordingState() {
         let isActive = NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.values.contains(true)
         updateScreenRecordingStateIfChanged(isActive: isActive)
-    }
-
-    private static func captureEvent(event: NIDEventName) {
-        let event = NIDEvent(type: event, url: NeuroID.getScreenName())
-        NeuroIDCore.shared.saveEventToLocalDataStore(event, screen: NeuroID.getScreenName() ?? ParamsCreator.generateID())
     }
 }

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -1,0 +1,139 @@
+//
+//  ListenerManagerService.swift
+//  NeuroID
+//
+
+import Foundation
+import UIKit
+
+protocol ListenerManagerServiceProtocol {
+    @MainActor
+    func startAppEventListeners()
+    @MainActor
+    func stopAppEventListeners()
+    @MainActor
+    func observeSceneCaptureEvents(inScreen controller: UIViewController?)
+}
+
+final class ListenerManagerService: ListenerManagerServiceProtocol {
+    private var appEventObservers: [NSObjectProtocol] = []
+
+    @MainActor
+    func startAppEventListeners() {
+        guard appEventObservers.isEmpty else { return }
+
+        // Screenshot Observer
+        appEventObservers.append(
+            NotificationCenter.default.addObserver(
+                forName: UIApplication.userDidTakeScreenshotNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.captureEvent(event: .screenCapture)
+            }
+        )
+
+        // Screen Recording Events for <iOS 17.0
+        if #unavailable(iOS 17.0) {
+            appEventObservers.append(
+                NotificationCenter.default.addObserver(
+                    forName: UIScreen.capturedDidChangeNotification,
+                    object: UIScreen.main,
+                    queue: .main
+                ) { [weak self] _ in
+                    self?.updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
+                }
+            )
+
+            updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
+        } else {
+            appEventObservers.append(
+                NotificationCenter.default.addObserver(
+                    forName: UIScene.didDisconnectNotification,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] notification in
+                    guard let scene = notification.object as? UIScene else { return }
+                    self?.sceneDidDisconnect(sceneID: scene.session.persistentIdentifier)
+                }
+            )
+            performInitialSceneCaptureCheck()
+        }
+    }
+
+    @MainActor
+    func stopAppEventListeners() {
+        guard !appEventObservers.isEmpty else { return }
+        appEventObservers.forEach { NotificationCenter.default.removeObserver($0) }
+        appEventObservers.removeAll()
+    }
+
+    @MainActor
+    func observeSceneCaptureEvents(inScreen controller: UIViewController?) {
+        guard #available(iOS 17.0, *), let scene = controller?.viewIfLoaded?.window?.windowScene else { return }
+
+        let sceneID = scene.session.persistentIdentifier
+        
+        if NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] == nil {
+            NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = scene.traitCollection.sceneCaptureState == .active
+
+            let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) {
+                [weak self] (windowScene: UIWindowScene, previousTraitCollection: UITraitCollection) in
+                self?.updateSceneCaptureState(
+                    sceneID: windowScene.session.persistentIdentifier,
+                    isActive: windowScene.traitCollection.sceneCaptureState == .active
+                )
+            }
+            NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = registration as AnyObject
+        }
+    }
+
+    func updateScreenRecordingStateIfChanged(isActive: Bool) {
+        if NeuroIDCore.shared.screenCaptureLastKnownState == nil {
+            NeuroIDCore.shared.screenCaptureLastKnownState = isActive
+            if isActive {
+                captureEvent(event: .screenRecordingStarted)
+            }
+            return
+        }
+
+        guard NeuroIDCore.shared.screenCaptureLastKnownState != isActive else { return }
+        NeuroIDCore.shared.screenCaptureLastKnownState = isActive
+        captureEvent(event: isActive ? .screenRecordingStarted : .screenRecordingStopped)
+    }
+
+    @available(iOS 17.0, *)
+    private func updateSceneCaptureState(sceneID: String, isActive: Bool) {
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = isActive
+        refreshSceneAggregateRecordingState()
+    }
+
+    @available(iOS 17.0, *)
+    func sceneDidDisconnect(sceneID: String) {
+        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeValue(forKey: sceneID)
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeValue(forKey: sceneID)
+        refreshSceneAggregateRecordingState()
+    }
+
+    @available(iOS 17.0, *)
+    func refreshSceneAggregateRecordingState() {
+        let isActive = NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.values.contains(true)
+        updateScreenRecordingStateIfChanged(isActive: isActive)
+    }
+    
+    @available(iOS 17.0, *)
+    func performInitialSceneCaptureCheck() {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        for scene in scenes {
+            let sceneID = scene.session.persistentIdentifier
+            NeuroIDCore.shared
+                .sceneCaptureLastKnownStateBySceneID[sceneID] = scene.traitCollection.sceneCaptureState == .active
+        }
+        refreshSceneAggregateRecordingState()
+    }
+
+    private func captureEvent(event: NIDEventName) {
+        let event = NIDEvent(type: event, url: NeuroID.getScreenName())
+        NeuroIDCore.shared.saveEventToLocalDataStore(event, screen: NeuroID.getScreenName() ?? ParamsCreator.generateID())
+    }
+}

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -138,12 +138,9 @@ extension ListenerManagerService {
 
     func registerSceneIfNeeded(_ scene: UIWindowScene) {
         guard #available(iOS 17.0, *) else { return }
-
         let sceneID = scene.session.persistentIdentifier
         guard NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] == nil else { return }
-
         NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = scene.traitCollection.sceneCaptureState == .active
-        
         let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) {
             [weak self] (windowScene: UIWindowScene, _: UITraitCollection) in
             let changedSceneID = windowScene.session.persistentIdentifier
@@ -152,7 +149,6 @@ extension ListenerManagerService {
                 self?.handleSceneCaptureTraitChange(sceneID: changedSceneID, isActive: isActive)
             }
         }
-
         NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = registration as AnyObject
         refreshSceneAggregateRecordingState()
     }

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -6,142 +6,204 @@
 import Foundation
 import UIKit
 
+@MainActor
 protocol ListenerManagerServiceProtocol {
-    @MainActor
     func startAppEventListeners()
-    @MainActor
     func stopAppEventListeners()
-    @MainActor
-    func observeSceneCaptureEvents(inScreen controller: UIViewController?)
 }
 
+@MainActor
 final class ListenerManagerService: ListenerManagerServiceProtocol {
-    
+
     let notificationCenter: NotificationCenter
-    private var appEventObservers: [NSObjectProtocol]
-    
-    init(notificationCenter: NotificationCenter) {
+    private var appEventObservers: [NSObjectProtocol] = []
+
+    nonisolated init(notificationCenter: NotificationCenter) {
         self.notificationCenter = notificationCenter
-        self.appEventObservers = []
     }
-    
-    // Attach listeners to notification center events
-    @MainActor
+
     func startAppEventListeners() {
         guard appEventObservers.isEmpty else { return }
 
-        // Screen Capture (screenshot) Observer
+        startScreenshotObserver()
+        startSceneLifecycleObservers()
+
+        if #available(iOS 17.0, *) {
+            registerExistingScenes()
+            refreshSceneAggregateRecordingState()
+        } else {
+            startLegacyScreenRecordingObserver()
+            updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
+        }
+    }
+
+    func stopAppEventListeners() {
+        guard !appEventObservers.isEmpty else { return }
+
+        appEventObservers.forEach { notificationCenter.removeObserver($0) }
+        appEventObservers.removeAll()
+
+        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeAll()
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeAll()
+        NeuroIDCore.shared.screenCaptureLastKnownState = nil
+    }
+}
+
+// MARK: - Observer Registration
+extension ListenerManagerService {
+    func startScreenshotObserver() {
         appEventObservers.append(
             notificationCenter.addObserver(
                 forName: UIApplication.userDidTakeScreenshotNotification,
                 object: nil,
                 queue: .main
-            ) { message in
-                ListenerManagerService.captureEvent(event: NIDEvent(type: .screenCapture))
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.handleScreenshotNotification()
+                }
+            }
+        )
+    }
+
+    func startSceneLifecycleObservers() {
+        appEventObservers.append(
+            notificationCenter.addObserver(
+                forName: UIScene.didActivateNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                guard let scene = notification.object as? UIWindowScene else { return }
+                Task { @MainActor [weak self] in
+                    self?.handleSceneDidActivate(scene)
+                }
             }
         )
 
-        // Screen Recording Events for <iOS 17.0
-        if #unavailable(iOS 17.0) {
-            appEventObservers.append(
-                notificationCenter.addObserver(
-                    forName: UIScreen.capturedDidChangeNotification,
-                    object: UIScreen.main,
-                    queue: .main
-                ) { message in
-                    self.updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
+        appEventObservers.append(
+            notificationCenter.addObserver(
+                forName: UIScene.didDisconnectNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                guard let scene = notification.object as? UIScene else { return }
+                Task { @MainActor [weak self] in
+                    self?.handleSceneDidDisconnect(sceneID: scene.session.persistentIdentifier)
                 }
-            )
-
-            // Initial check to see if the screen is observed
-            updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
-        }
-        
-        // Handles scene disconnects for iOS 17.0+
-        if #available(iOS 17.0, *) {
-            appEventObservers.append(
-                notificationCenter.addObserver(
-                    forName: UIScene.didDisconnectNotification,
-                    object: nil,
-                    queue: .main
-                ) { notification in
-                    guard let scene = notification.object as? UIScene else { return }
-                    self.sceneDidDisconnect(sceneID: scene.session.persistentIdentifier)
-                }
-            )
-
-            // Initial capture check across all connected scenes
-            for scene in UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }) {
-                NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[scene.session.persistentIdentifier] =
-                    scene.traitCollection.sceneCaptureState == .active
             }
-            refreshSceneAggregateRecordingState()
-        }
+        )
     }
 
-    @MainActor
-    func stopAppEventListeners() {
-        guard !appEventObservers.isEmpty else { return }
-        appEventObservers.forEach { notificationCenter.removeObserver($0) }
-        appEventObservers.removeAll()
-    }
-
-    private static func captureEvent(event: NIDEvent) {
-        event.url = NeuroID.getScreenName()
-        NeuroIDCore.shared.saveEventToLocalDataStore(event, screen: NeuroID.getScreenName() ?? ParamsCreator.generateID())
+    func startLegacyScreenRecordingObserver() {
+        appEventObservers.append(
+            notificationCenter.addObserver(
+                forName: UIScreen.capturedDidChangeNotification,
+                object: UIScreen.main,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.handleLegacyScreenCaptureChange(isCaptured: UIScreen.main.isCaptured)
+                }
+            }
+        )
     }
 }
 
-// Screen Recording Logic
+// MARK: - Notification Handlers
 extension ListenerManagerService {
+    func handleScreenshotNotification() {
+        captureEvent(event: NIDEvent(type: .screenCapture))
+    }
 
-    // Start observing events at the view controller
-    @MainActor
-    func observeSceneCaptureEvents(inScreen controller: UIViewController?) {
-        guard #available(iOS 17.0, *), let scene = controller?.viewIfLoaded?.window?.windowScene else { return }
+    func handleLegacyScreenCaptureChange(isCaptured: Bool) {
+        updateScreenRecordingStateIfChanged(isActive: isCaptured)
+    }
 
-        let sceneID = scene.session.persistentIdentifier
-        
-        if NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] == nil {
-            NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = scene.traitCollection.sceneCaptureState == .active
+    func handleSceneDidActivate(_ scene: UIWindowScene) {
+        registerSceneIfNeeded(scene)
+    }
 
-            let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) { (windowScene: UIWindowScene, previousTraitCollection: UITraitCollection) in
-                NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[windowScene.session.persistentIdentifier] = windowScene.traitCollection.sceneCaptureState == .active
-                self.refreshSceneAggregateRecordingState()
-            }
-            NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = registration as AnyObject
+    func handleSceneDidDisconnect(sceneID: String) {
+        sceneDidDisconnect(sceneID: sceneID)
+    }
+}
+
+// MARK: - Scene Tracking
+extension ListenerManagerService {
+    @available(iOS 17.0, *)
+    func registerExistingScenes() {
+        for case let scene as UIWindowScene in UIApplication.shared.connectedScenes {
+            registerSceneIfNeeded(scene)
         }
     }
 
+    func registerSceneIfNeeded(_ scene: UIWindowScene) {
+        guard #available(iOS 17.0, *) else { return }
+
+        let sceneID = scene.session.persistentIdentifier
+        guard NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] == nil else { return }
+
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = scene.traitCollection.sceneCaptureState == .active
+        
+        let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) {
+            [weak self] (windowScene: UIWindowScene, _: UITraitCollection) in
+            let changedSceneID = windowScene.session.persistentIdentifier
+            let isActive = windowScene.traitCollection.sceneCaptureState == .active
+            Task { @MainActor [weak self] in
+                self?.handleSceneCaptureTraitChange(sceneID: changedSceneID, isActive: isActive)
+            }
+        }
+
+        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = registration as AnyObject
+        refreshSceneAggregateRecordingState()
+    }
+
+    @available(iOS 17.0, *)
+    func handleSceneCaptureTraitChange(sceneID: String, isActive: Bool) {
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = isActive
+        refreshSceneAggregateRecordingState()
+    }
+
+    func sceneDidDisconnect(sceneID: String) {
+        if #available(iOS 17.0, *) {
+            NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeValue(forKey: sceneID)
+            NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeValue(forKey: sceneID)
+            refreshSceneAggregateRecordingState()
+        }
+    }
+}
+
+// MARK: - Screen Recording State
+extension ListenerManagerService {
     func updateScreenRecordingStateIfChanged(isActive: Bool) {
-        //If there was no known state, set a baseline
         let event = NIDEvent(type: .screenRecording)
         if NeuroIDCore.shared.screenCaptureLastKnownState == nil {
             NeuroIDCore.shared.screenCaptureLastKnownState = isActive
             if isActive {
                 event.attrs = [Attrs(n: "state", v: "active")]
-                ListenerManagerService.captureEvent(event: event)
+                captureEvent(event: event)
             }
             return
         }
-
         guard NeuroIDCore.shared.screenCaptureLastKnownState != isActive else { return }
         NeuroIDCore.shared.screenCaptureLastKnownState = isActive
-
         event.attrs = [Attrs(n: "state", v: isActive ? "active" : "inactive")]
-        ListenerManagerService.captureEvent(event: event)
-    }
-
-    @available(iOS 17.0, *)
-    func sceneDidDisconnect(sceneID: String) {
-        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeValue(forKey: sceneID)
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeValue(forKey: sceneID)
-        refreshSceneAggregateRecordingState()
+        captureEvent(event: event)
     }
 
     @available(iOS 17.0, *)
     func refreshSceneAggregateRecordingState() {
         let isActive = NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.values.contains(true)
         updateScreenRecordingStateIfChanged(isActive: isActive)
+    }
+}
+
+// MARK: - Event Capture
+extension ListenerManagerService {
+    fileprivate func captureEvent(event: NIDEvent) {
+        event.url = NeuroID.getScreenName()
+        NeuroIDCore.shared.saveEventToLocalDataStore(
+            event,
+            screen: NeuroID.getScreenName() ?? ParamsCreator.generateID()
+        )
     }
 }

--- a/Source/NeuroID/TrackerClassExtensions/BaseClassExtensions/Date.swift
+++ b/Source/NeuroID/TrackerClassExtensions/BaseClassExtensions/Date.swift
@@ -11,8 +11,6 @@ extension Date {
     func toString() -> String {
         let df = DateFormatter()
         df.dateFormat = "yyyy-MM-dd hh:mm:ss"
-        let dpValue = df.string(from: self)
-
-        return dpValue
+        return df.string(from: self)
     }
 }

--- a/Source/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/Source/NeuroID/TrackerClassExtensions/Utils.swift
@@ -57,7 +57,8 @@ enum UtilFunctions {
     static func registerRecursiveUIViewController(controller: UIViewController, parentTag: String) -> [(UIViewController, String)] {
         var list: [(UIViewController, String)] = []
 
-        let shouldIgnore = controller.ignoreLists.contains(controller.nidClassName)
+        // TODO: why is the ignore list is not being honored here
+        let _ = controller.ignoreLists.contains(controller.nidClassName)
 
         if controller.children.isEmpty {
             list.append(

--- a/Source/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/Source/NeuroID/TrackerClassExtensions/Utils.swift
@@ -86,6 +86,7 @@ enum UtilFunctions {
         return list
     }
 
+    @MainActor
     static func registerSubViewsTargets(controller: UIViewController) {
         // self
         NIDLog.debug("\(Constants.registrationTag.rawValue) Registering Top Level UIViewController \(controller.nidClassName)")

--- a/Source/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/Source/NeuroID/TrackerClassExtensions/Utils.swift
@@ -57,8 +57,7 @@ enum UtilFunctions {
     static func registerRecursiveUIViewController(controller: UIViewController, parentTag: String) -> [(UIViewController, String)] {
         var list: [(UIViewController, String)] = []
 
-        // TODO: why is the ignore list is not being honored here
-        let _ = controller.ignoreLists.contains(controller.nidClassName)
+        let shouldIgnore = controller.ignoreLists.contains(controller.nidClassName)
 
         if controller.children.isEmpty {
             list.append(

--- a/Source/NeuroID/TrackerEvents/AppEvents.swift
+++ b/Source/NeuroID/TrackerEvents/AppEvents.swift
@@ -33,7 +33,7 @@ extension NeuroIDTracker {
             object: nil
         )
         
-        NeuroIDCore.shared.listenerManager?.startAppEventListeners()
+        NeuroIDCore.shared.listenerManager.startAppEventListeners()
     }
 
     @objc func appMovedToBackground() {

--- a/Source/NeuroID/TrackerEvents/AppEvents.swift
+++ b/Source/NeuroID/TrackerEvents/AppEvents.swift
@@ -32,7 +32,7 @@ extension NeuroIDTracker {
             name: UIApplication.didReceiveMemoryWarningNotification,
             object: nil
         )
-        
+
         // Screenshot Events
         appEventObservers.append(
             NotificationCenter.default.addObserver(
@@ -40,21 +40,22 @@ extension NeuroIDTracker {
                 object: nil,
                 queue: .main
             ) { [weak self] _ in
-                self?.screenCapture()
+                self?.captureEvent(event: NIDEvent(type: .screenCapture))
             }
         )
 
-        // Screen Recording Events
-        appEventObservers.append(
-            NotificationCenter.default.addObserver(
-                forName: UIScreen.capturedDidChangeNotification,
-                object: UIScreen.main,
-                queue: .main
-            ) { [weak self] _ in
-                self?.screenRecording()
-            }
-        )
-                
+        // Screen Recording Events for <iOS 17.0
+        if #unavailable(iOS 17.0) {
+            appEventObservers.append(
+                NotificationCenter.default.addObserver(
+                    forName: UIScreen.capturedDidChangeNotification,
+                    object: UIScreen.main,
+                    queue: .main
+                ) { [weak self] _ in
+                    self?.screenRecording(isCaptured: UIScreen.main.isCaptured)
+                }
+            )
+        }
     }
 
     @objc func appMovedToBackground() {
@@ -95,7 +96,42 @@ extension NeuroIDTracker {
         captureEvent(event: NIDEvent(type: .screenCapture))
     }
 
-    func screenRecording() {
-        captureEvent(event: NIDEvent(type: .screenRecording))
+    func screenRecording(isCaptured: Bool) {
+        captureEvent(event: NIDEvent(type: isCaptured ? .screenRecordingStarted : .screenRecordingStopped))
+    }
+
+    func observeSceneCaptureEvents(inScreen controller: UIViewController?) {
+        guard #available(iOS 17.0, *), let scene = controller?.viewIfLoaded?.window?.windowScene else { return }
+
+        let sceneID = scene.session.persistentIdentifier
+        if NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] == nil {
+            let initialActive = scene.traitCollection.sceneCaptureState == .active
+            NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = initialActive
+
+            let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) {
+                [weak self] (windowScene: UIWindowScene, previousTraitCollection: UITraitCollection) in
+                self?.captureSceneCaptureStateChange(
+                    sceneID: windowScene.session.persistentIdentifier,
+                    isActive: windowScene.traitCollection.sceneCaptureState == .active
+                )
+            }
+            NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = registration as AnyObject
+
+            if initialActive {
+                screenRecording(isCaptured: true)
+            }
+        } else {
+            captureSceneCaptureStateChange(
+                sceneID: sceneID,
+                isActive: scene.traitCollection.sceneCaptureState == .active
+            )
+        }
+    }
+
+    @available(iOS 17.0, *)
+    func captureSceneCaptureStateChange(sceneID: String, isActive: Bool) {
+        guard NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] != isActive else { return }
+        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = isActive
+        screenRecording(isCaptured: isActive)
     }
 }

--- a/Source/NeuroID/TrackerEvents/AppEvents.swift
+++ b/Source/NeuroID/TrackerEvents/AppEvents.swift
@@ -32,30 +32,8 @@ extension NeuroIDTracker {
             name: UIApplication.didReceiveMemoryWarningNotification,
             object: nil
         )
-
-        // Screenshot Events
-        appEventObservers.append(
-            NotificationCenter.default.addObserver(
-                forName: UIApplication.userDidTakeScreenshotNotification,
-                object: nil,
-                queue: .main
-            ) { [weak self] _ in
-                self?.captureEvent(event: NIDEvent(type: .screenCapture))
-            }
-        )
-
-        // Screen Recording Events for <iOS 17.0
-        if #unavailable(iOS 17.0) {
-            appEventObservers.append(
-                NotificationCenter.default.addObserver(
-                    forName: UIScreen.capturedDidChangeNotification,
-                    object: UIScreen.main,
-                    queue: .main
-                ) { [weak self] _ in
-                    self?.screenRecording(isCaptured: UIScreen.main.isCaptured)
-                }
-            )
-        }
+        
+        NeuroIDCore.shared.listenerManager?.startAppEventListeners()
     }
 
     @objc func appMovedToBackground() {
@@ -90,48 +68,5 @@ extension NeuroIDTracker {
         DispatchQueue.main.asyncAfter(deadline: .now() + lowMembackOffTime) {
             NeuroIDCore.shared.lowMemory = false
         }
-    }
-
-    func screenCapture() {
-        captureEvent(event: NIDEvent(type: .screenCapture))
-    }
-
-    func screenRecording(isCaptured: Bool) {
-        captureEvent(event: NIDEvent(type: isCaptured ? .screenRecordingStarted : .screenRecordingStopped))
-    }
-
-    func observeSceneCaptureEvents(inScreen controller: UIViewController?) {
-        guard #available(iOS 17.0, *), let scene = controller?.viewIfLoaded?.window?.windowScene else { return }
-
-        let sceneID = scene.session.persistentIdentifier
-        if NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] == nil {
-            let initialActive = scene.traitCollection.sceneCaptureState == .active
-            NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = initialActive
-
-            let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) {
-                [weak self] (windowScene: UIWindowScene, previousTraitCollection: UITraitCollection) in
-                self?.captureSceneCaptureStateChange(
-                    sceneID: windowScene.session.persistentIdentifier,
-                    isActive: windowScene.traitCollection.sceneCaptureState == .active
-                )
-            }
-            NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = registration as AnyObject
-
-            if initialActive {
-                screenRecording(isCaptured: true)
-            }
-        } else {
-            captureSceneCaptureStateChange(
-                sceneID: sceneID,
-                isActive: scene.traitCollection.sceneCaptureState == .active
-            )
-        }
-    }
-
-    @available(iOS 17.0, *)
-    func captureSceneCaptureStateChange(sceneID: String, isActive: Bool) {
-        guard NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] != isActive else { return }
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = isActive
-        screenRecording(isCaptured: isActive)
     }
 }


### PR DESCRIPTION
Updates screen recording detection to use the modern iOS 17+ `UITraitSceneCaptureState` API, with a proper fallback to UIScreen.capturedDidChangeNotification for older versions.

---

Screen recording (SCREEN_RECORDING)                                                                                                                                                                                                         
- iOS 17+: registers per-scene trait change callbacks via registerForTraitChanges([UITraitSceneCaptureState.self]), replacing the deprecated traitCollectionDidChange override
- Pre-iOS 17: continues using UIScreen.capturedDidChangeNotification                                                                                                                                                                     
- Aggregate state logic: any one scene actively capturing = device is recording (OR across all scenes)
- Handles scenes connected before SDK start, scenes activating after start, and scene disconnects                                                                                                                                            
- Emits a single SCREEN_RECORDING event with attrs: [{ n: "state", v: "active"|"inactive" }]; deduplicates consecutive identical states

Screenshot (SCREEN_CAPTURE)
- Fires on UIApplication.userDidTakeScreenshotNotification

ListenerManagerService refactor                                                                                                                                                                                                              
- Extracted into ListenerManagerService with a ListenerManagerServiceProtocol for testability
- Scene lifecycle management (sceneCaptureRegistrationsBySceneID, sceneCaptureLastKnownStateBySceneID) scoped to the service

[ENG-11697]

[ENG-11697]: https://neuro-id.atlassian.net/browse/ENG-11697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ