### PR TITLE
[ENG-11756] Isolate UI helpers to main actor for concurrency support

### DIFF
--- a/SDKTest/UtilFunctionsTests.swift
+++ b/SDKTest/UtilFunctionsTests.swift
@@ -8,6 +8,7 @@
 @testable import NeuroID
 import XCTest
 
+@MainActor
 final class UtilFunctionsTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
     let userId = "form_mobilesandbox"

--- a/SDKTest/Utils/NIDParamsCreatorTests.swift
+++ b/SDKTest/Utils/NIDParamsCreatorTests.swift
@@ -8,6 +8,7 @@
 @testable import NeuroID
 import XCTest
 
+@MainActor
 class NIDParamsCreatorTests: XCTestCase {
     // consts
     let tgsKey = Constants.tgsKey.rawValue

--- a/SDKTest/Utils/TouchEventsTests.swift
+++ b/SDKTest/Utils/TouchEventsTests.swift
@@ -8,6 +8,7 @@
 @testable import NeuroID
 import XCTest
 
+@MainActor
 class TouchEventTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
 

--- a/Source/NeuroID/Models/DeviceMetadata.swift
+++ b/Source/NeuroID/Models/DeviceMetadata.swift
@@ -188,7 +188,7 @@ extension DeviceMetadata {
     }
 
     // suspicious apps path to check
-    static var suspiciousAppsPathToCheck: [String] = [
+    static let suspiciousAppsPathToCheck: [String] = [
         "/Applications/Cydia.app",
         "/Applications/blackra1n.app",
         "/Applications/FakeCarrier.app",
@@ -201,7 +201,7 @@ extension DeviceMetadata {
     ]
 
     // suspicious system paths to check
-    static var suspiciousSystemPathsToCheck: [String] = [
+    static let suspiciousSystemPathsToCheck: [String] = [
         "/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
         "/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
         "/private/var/lib/apt",

--- a/Source/NeuroID/NIDParamsCreator.swift
+++ b/Source/NeuroID/NIDParamsCreator.swift
@@ -11,6 +11,7 @@ import UIKit
 // MARK: - Properties - temporary public for testing
 
 enum ParamsCreator {
+    @MainActor
     static func getTgParams(view: UIView, extraParams: [String: TargetValue] = [:]) -> [String: TargetValue] {
         // TODO, figure out if we need to find super class of ETN
         var params: [String: TargetValue] = [
@@ -28,6 +29,7 @@ enum ParamsCreator {
         return Int64(Date().timeIntervalSince1970 * 1000)
     }
 
+    @MainActor
     static func getTGParamsForInput(
         eventName: NIDEventName,
         view: UIView,
@@ -70,6 +72,7 @@ enum ParamsCreator {
         return params
     }
 
+    @MainActor
     static func getUiControlTgParams(sender: UIView) -> [String: TargetValue] {
         var tg: [String: TargetValue] = [
             "sender": TargetValue.string(sender.nidClassName),

--- a/Source/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/Source/NeuroID/TrackerClassExtensions/Utils.swift
@@ -24,6 +24,7 @@ enum UtilFunctions {
         }
     }
 
+    @MainActor
     static func getParentRecursively(viewController: UIViewController) -> [String] {
         if let parent = viewController.parent {
             return [parent.nidClassName] + getParentRecursively(viewController: parent)
@@ -36,6 +37,7 @@ enum UtilFunctions {
         This method will take the UIView and navigate back through its entire ancestory tree to produce
         a path from the highest UIViewController down to the element.
      */
+    @MainActor
     static func getFullViewlURLPath(currView: UIView) -> String {
         let viewControllerParent = currView.viewController
 
@@ -54,6 +56,7 @@ enum UtilFunctions {
         return "\(finalPath)/\(currView.nidClassName)"
     }
 
+    @MainActor
     static func registerRecursiveUIViewController(controller: UIViewController, parentTag: String) -> [(UIViewController, String)] {
         var list: [(UIViewController, String)] = []
 
@@ -164,6 +167,7 @@ enum UtilFunctions {
         NIDLog.debug("\(Constants.registrationTag.rawValue)            Registered View: \(className) - \(id)")
     }
 
+    @MainActor
     static func captureContextMenuAction(
         type: NIDEventName,
         view: UIView,
@@ -200,6 +204,7 @@ enum UtilFunctions {
         )
     }
 
+    @MainActor
     static func captureTextEvents(view: UIView, textValue: String, eventType: NIDEventName) {
         let id = view.id
         let inputType = "text"
@@ -238,6 +243,7 @@ enum UtilFunctions {
         }
     }
 
+    @MainActor
     static func captureInputTextChangeEvent(
         eventType: NIDEventName,
         textControl: UIView,
@@ -304,6 +310,7 @@ enum UtilFunctions {
         )
     }
 
+    @MainActor
     static func extractTouchesFromEvent(uiView: UIView, event: UIEvent) -> [NIDTouches] {
         if let touches = event.allTouches {
             return extractTouchInfoFromTouchArray(touches)
@@ -312,6 +319,7 @@ enum UtilFunctions {
         }
     }
 
+    @MainActor
     static func extractTouchInfoFromTouchArray(_ touches: Set<UITouch>) -> [NIDTouches] {
         var touchArray: [NIDTouches] = []
 
@@ -336,6 +344,7 @@ enum UtilFunctions {
         return touchArray
     }
 
+    @MainActor
     static func extractTouchesFromGestureRecognizer(
         gestureRecognizer: UIGestureRecognizer
     ) -> [NIDTouches] {
@@ -358,6 +367,7 @@ enum UtilFunctions {
         return touchArray
     }
 
+    @MainActor
     static func createTouchEvent(sender: UIView, eventName: NIDEventName, location: String, touches: [NIDTouches]) -> NIDEvent {
         let viewId = TargetValue.string(sender.id)
 

--- a/Source/NeuroID/TrackerEvents/TouchEvents.swift
+++ b/Source/NeuroID/TrackerEvents/TouchEvents.swift
@@ -43,6 +43,7 @@ extension NeuroIDTracker {
     }
 }
 
+@MainActor
 class CustomTapGestureRecognizer: UITapGestureRecognizer {
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesBegan(touches, with: event)
@@ -57,6 +58,7 @@ class CustomTapGestureRecognizer: UITapGestureRecognizer {
     }
 }
 
+@MainActor
 func captureTouchInfo(gesture: UITapGestureRecognizer, touches: Set<UITouch>, type: NIDEventName) {
     var size: CGFloat = 0.0
     var force: CGFloat = 0.0
@@ -72,6 +74,7 @@ func captureTouchInfo(gesture: UITapGestureRecognizer, touches: Set<UITouch>, ty
     )
 }
 
+@MainActor
 func captureTouchEvent(
     type: NIDEventName,
     gestureRecognizer: UIGestureRecognizer,


### PR DESCRIPTION
Isolate several UI component related helper functions to the main actor (`@MainActor`) for concurrency support. Resolves 50+ warnings.

[ENG-11756]

[ENG-11756]: https://neuro-id.atlassian.net/browse/ENG-11756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ