### PR TITLE
[ENG-11756] Isolate screen capture/recording state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         include:
           # Check Apple Developer for information on device and Swift version support: https://developer.apple.com/support/xcode/
-          
+
           # Latest
           - macos: 26
             xcode: '26.4'   # Swift 6.3
@@ -76,7 +76,15 @@ jobs:
       - name: Prepare Simulator
         run: |
           set -o pipefail
-          xcrun simctl boot "${{ matrix.ios-simulator }} (${{ matrix.ios-version }})" || true
+          
+          # Find the UDID for the specified simulator and iOS version
+          SIMULATOR_UDID=$(
+            xcrun simctl list -j devices available | \
+            jq -r --arg name "${{ matrix.ios-simulator }}" --arg ver "${{ matrix.ios-version }}" \
+            '.devices | to_entries[] | select($ver == "latest" or (.key | contains($ver | gsub("\\."; "-")))) | .value[] | select(.name == $name) | .udid' | head -1
+          )
+
+          xcrun simctl boot "$SIMULATOR_UDID"
           xcrun simctl list devices
 
       - name: Build and Test (Simulator)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Prepare Simulator
         run: |
           set -o pipefail
-          xcrun simctl boot "${{ matrix.ios-simulator }}" || true
+          xcrun simctl boot "${{ matrix.ios-simulator }} (${{ matrix.ios-version }})" || true
           xcrun simctl list devices
 
       - name: Build and Test (Simulator)

--- a/SDKTest/Services/ListenerManagerServiceTests.swift
+++ b/SDKTest/Services/ListenerManagerServiceTests.swift
@@ -12,19 +12,22 @@ import UIKit
 @MainActor
 struct ListenerManagerServiceTests {
 
+    var uiRuntime: UIRuntime
     var notificationCenter: NotificationCenter
     var listenerManagerService: ListenerManagerService
     var dataStore: DataStore
 
     init() {
+        self.uiRuntime = UIRuntime()
         self.notificationCenter = NotificationCenter()
-        self.listenerManagerService = ListenerManagerService(notificationCenter: notificationCenter)
+        self.listenerManagerService = ListenerManagerService(
+            uiRuntime: uiRuntime,
+            notificationCenter: notificationCenter
+        )
         self.dataStore = DataStore()
         NeuroIDCore.shared._isSDKStarted = true
         NeuroIDCore.shared.datastore = dataStore
-        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeAll()
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeAll()
-        NeuroIDCore.shared.screenCaptureLastKnownState = nil
+        uiRuntime.resetScreenCaptureTrackingState()
     }
 
     func screenRecordingEvents() -> [NIDEvent] {
@@ -64,13 +67,13 @@ struct ListenerManagerServiceTests {
     @Test
     func stopAppEventListeners_clearsScreenCaptureTrackingState() {
         listenerManagerService.startAppEventListeners()
-        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["scene"] = NSObject()
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["scene"] = true
-        NeuroIDCore.shared.screenCaptureLastKnownState = true
+        uiRuntime.sceneCaptureRegistrationsBySceneID["scene"] = NSObject()
+        uiRuntime.sceneCaptureLastKnownStateBySceneID["scene"] = true
+        uiRuntime.screenCaptureLastKnownState = true
         listenerManagerService.stopAppEventListeners()
-        #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.isEmpty)
-        #expect(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.isEmpty)
-        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == nil)
+        #expect(uiRuntime.sceneCaptureRegistrationsBySceneID.isEmpty)
+        #expect(uiRuntime.sceneCaptureLastKnownStateBySceneID.isEmpty)
+        #expect(uiRuntime.screenCaptureLastKnownState == nil)
     }
 
     @Test
@@ -82,7 +85,7 @@ struct ListenerManagerServiceTests {
         #expect(events.count == 2)
         #expect(events[0].attrs == [Attrs(n: "state", v: "active")])
         #expect(events[1].attrs == [Attrs(n: "state", v: "inactive")])
-        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
+        #expect(uiRuntime.screenCaptureLastKnownState == false)
     }
 
     @Test
@@ -94,7 +97,7 @@ struct ListenerManagerServiceTests {
         #expect(events.count == 2)
         #expect(events[0].attrs == [Attrs(n: "state", v: "active")])
         #expect(events[1].attrs == [Attrs(n: "state", v: "inactive")])
-        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
+        #expect(uiRuntime.screenCaptureLastKnownState == false)
     }
 
     @Test
@@ -102,7 +105,7 @@ struct ListenerManagerServiceTests {
         listenerManagerService.startLegacyScreenRecordingObserver()
         notificationCenter.post(name: UIScreen.capturedDidChangeNotification, object: UIScreen.main)
         await Task.yield()
-        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == UIScreen.main.isCaptured)
+        #expect(uiRuntime.screenCaptureLastKnownState == UIScreen.main.isCaptured)
     }
 
     @available(iOS 17.0, *)
@@ -110,13 +113,13 @@ struct ListenerManagerServiceTests {
     func registerSceneIfNeeded_registersConnectedSceneState() {
         let scenes = connectedWindowScenes()
         guard let scene = scenes.first else { return }
-        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeAll()
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeAll()
+        uiRuntime.sceneCaptureRegistrationsBySceneID.removeAll()
+        uiRuntime.sceneCaptureLastKnownStateBySceneID.removeAll()
         listenerManagerService.registerSceneIfNeeded(scene)
         let sceneID = scene.session.persistentIdentifier
-        #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] != nil)
+        #expect(uiRuntime.sceneCaptureRegistrationsBySceneID[sceneID] != nil)
         #expect(
-            NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID]
+            uiRuntime.sceneCaptureLastKnownStateBySceneID[sceneID]
                 == (scene.traitCollection.sceneCaptureState == .active)
         )
     }
@@ -126,14 +129,14 @@ struct ListenerManagerServiceTests {
     func registerExistingScenes_registersEachConnectedScene() {
         let scenes = connectedWindowScenes()
         guard !scenes.isEmpty else { return }
-        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeAll()
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeAll()
+        uiRuntime.sceneCaptureRegistrationsBySceneID.removeAll()
+        uiRuntime.sceneCaptureLastKnownStateBySceneID.removeAll()
         listenerManagerService.registerExistingScenes()
         for scene in scenes {
             let sceneID = scene.session.persistentIdentifier
-            #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] != nil)
+            #expect(uiRuntime.sceneCaptureRegistrationsBySceneID[sceneID] != nil)
             #expect(
-                NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID]
+                uiRuntime.sceneCaptureLastKnownStateBySceneID[sceneID]
                     == (scene.traitCollection.sceneCaptureState == .active)
             )
         }
@@ -144,13 +147,13 @@ struct ListenerManagerServiceTests {
     func handleSceneDidActivate_registersSceneIfNeeded() {
         let scenes = connectedWindowScenes()
         guard let scene = scenes.first else { return }
-        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeAll()
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeAll()
+        uiRuntime.sceneCaptureRegistrationsBySceneID.removeAll()
+        uiRuntime.sceneCaptureLastKnownStateBySceneID.removeAll()
         listenerManagerService.handleSceneDidActivate(scene)
         let sceneID = scene.session.persistentIdentifier
-        #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] != nil)
+        #expect(uiRuntime.sceneCaptureRegistrationsBySceneID[sceneID] != nil)
         #expect(
-            NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID]
+            uiRuntime.sceneCaptureLastKnownStateBySceneID[sceneID]
                 == (scene.traitCollection.sceneCaptureState == .active)
         )
     }
@@ -158,37 +161,37 @@ struct ListenerManagerServiceTests {
     @available(iOS 17.0, *)
     @Test
     func handleSceneCaptureTraitChange_updatesAggregateAndEmitsInactive() {
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneA"] = true
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneB"] = false
-        NeuroIDCore.shared.screenCaptureLastKnownState = true
+        uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneA"] = true
+        uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneB"] = false
+        uiRuntime.screenCaptureLastKnownState = true
         listenerManagerService.handleSceneCaptureTraitChange(sceneID: "sceneA", isActive: false)
-        #expect(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneA"] == false)
-        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
+        #expect(uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneA"] == false)
+        #expect(uiRuntime.screenCaptureLastKnownState == false)
         #expect(screenRecordingEvents().last?.attrs == [Attrs(n: "state", v: "inactive")])
     }
 
     @available(iOS 17.0, *)
     @Test
     func sceneDidDisconnect_removesSceneAndRefreshesAggregate() {
-        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["sceneA"] = NSObject()
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneA"] = true
-        NeuroIDCore.shared.screenCaptureLastKnownState = true
+        uiRuntime.sceneCaptureRegistrationsBySceneID["sceneA"] = NSObject()
+        uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneA"] = true
+        uiRuntime.screenCaptureLastKnownState = true
         listenerManagerService.sceneDidDisconnect(sceneID: "sceneA")
-        #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["sceneA"] == nil)
-        #expect(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneA"] == nil)
-        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
+        #expect(uiRuntime.sceneCaptureRegistrationsBySceneID["sceneA"] == nil)
+        #expect(uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneA"] == nil)
+        #expect(uiRuntime.screenCaptureLastKnownState == false)
         #expect(screenRecordingEvents().last?.attrs == [Attrs(n: "state", v: "inactive")])
     }
 
     @available(iOS 17.0, *)
     @Test
     func handleSceneDidDisconnect_routesToSceneDisconnectFlow() {
-        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["sceneB"] = NSObject()
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneB"] = true
-        NeuroIDCore.shared.screenCaptureLastKnownState = true
+        uiRuntime.sceneCaptureRegistrationsBySceneID["sceneB"] = NSObject()
+        uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneB"] = true
+        uiRuntime.screenCaptureLastKnownState = true
         listenerManagerService.handleSceneDidDisconnect(sceneID: "sceneB")
-        #expect(NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID["sceneB"] == nil)
-        #expect(NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID["sceneB"] == nil)
-        #expect(NeuroIDCore.shared.screenCaptureLastKnownState == false)
+        #expect(uiRuntime.sceneCaptureRegistrationsBySceneID["sceneB"] == nil)
+        #expect(uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneB"] == nil)
+        #expect(uiRuntime.screenCaptureLastKnownState == false)
     }
 }

--- a/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
@@ -21,6 +21,7 @@ class NeuroIDCore: NSObject {
     var linkedSiteID: String?
 
     // Services
+    var uiRuntime: UIRuntime
     var datastore: DataStoreServiceProtocol
     var eventStorageService: EventStorageServiceProtocol
     var validationService: ValidationServiceProtocol
@@ -108,10 +109,6 @@ class NeuroIDCore: NSObject {
 
     var lowMemory: Bool = false
 
-    var sceneCaptureRegistrationsBySceneID: [String: AnyObject] = [:]
-    var sceneCaptureLastKnownStateBySceneID: [String: Bool] = [:]
-    var screenCaptureLastKnownState: Bool?
-
     var packetNumber: Int32 = 0
 
     // Testing Purposes Only
@@ -120,6 +117,7 @@ class NeuroIDCore: NSObject {
     // MARK: - Setup
 
     init(
+        uiRuntime: UIRuntime? = nil,
         datastore: DataStoreServiceProtocol? = nil,
         eventStorageService: EventStorageServiceProtocol? = nil,
         validationService: ValidationServiceProtocol? = nil,
@@ -133,6 +131,7 @@ class NeuroIDCore: NSObject {
         locationManager: LocationManagerServiceProtocol? = nil,
         listenerManager: ListenerManagerService? = nil
     ) {
+        self.uiRuntime = uiRuntime ?? UIRuntime()
         self.datastore = datastore ?? DataStore()
         self.eventStorageService = eventStorageService ?? EventStorageService()
         self.validationService = validationService ?? ValidationService()
@@ -159,7 +158,12 @@ class NeuroIDCore: NSObject {
             )
         self.callObserver = callObserver
         self.locationManager = locationManager
-        self.listenerManager = listenerManager ?? ListenerManagerService(notificationCenter: .default)
+        self.listenerManager =
+            listenerManager
+            ?? ListenerManagerService(
+                uiRuntime: self.uiRuntime,
+                notificationCenter: .default
+            )
 
         self.sendCollectionEventsJob = RepeatingTask(
             interval: Double(self.configService.configCache.eventQueueFlushInterval),

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -15,10 +15,12 @@ protocol ListenerManagerServiceProtocol {
 @MainActor
 final class ListenerManagerService: ListenerManagerServiceProtocol {
 
+    let uiRuntime: UIRuntime
     let notificationCenter: NotificationCenter
     private var appEventObservers: [NSObjectProtocol] = []
 
-    nonisolated init(notificationCenter: NotificationCenter) {
+    nonisolated init(uiRuntime: UIRuntime, notificationCenter: NotificationCenter) {
+        self.uiRuntime = uiRuntime
         self.notificationCenter = notificationCenter
     }
 
@@ -48,9 +50,7 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
         }
         appEventObservers.removeAll()
 
-        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeAll()
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeAll()
-        NeuroIDCore.shared.screenCaptureLastKnownState = nil
+        uiRuntime.resetScreenCaptureTrackingState()
     }
 }
 
@@ -146,8 +146,8 @@ extension ListenerManagerService {
     func registerSceneIfNeeded(_ scene: UIWindowScene) {
         guard #available(iOS 17.0, *) else { return }
         let sceneID = scene.session.persistentIdentifier
-        guard NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] == nil else { return }
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = scene.traitCollection.sceneCaptureState == .active
+        guard uiRuntime.sceneCaptureRegistrationsBySceneID[sceneID] == nil else { return }
+        uiRuntime.sceneCaptureLastKnownStateBySceneID[sceneID] = scene.traitCollection.sceneCaptureState == .active
         // iOS 17+ replacement for the deprecated traitCollectionDidChange override
         let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) {
             [weak self] (windowScene: UIWindowScene, _: UITraitCollection) in
@@ -157,20 +157,20 @@ extension ListenerManagerService {
                 self?.handleSceneCaptureTraitChange(sceneID: changedSceneID, isActive: isActive)
             }
         }
-        NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID[sceneID] = registration as AnyObject
+        uiRuntime.sceneCaptureRegistrationsBySceneID[sceneID] = registration as AnyObject
         refreshSceneAggregateRecordingState()
     }
 
     @available(iOS 17.0, *)
     func handleSceneCaptureTraitChange(sceneID: String, isActive: Bool) {
-        NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID[sceneID] = isActive
+        uiRuntime.sceneCaptureLastKnownStateBySceneID[sceneID] = isActive
         refreshSceneAggregateRecordingState()
     }
 
     func sceneDidDisconnect(sceneID: String) {
         if #available(iOS 17.0, *) {
-            NeuroIDCore.shared.sceneCaptureRegistrationsBySceneID.removeValue(forKey: sceneID)
-            NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.removeValue(forKey: sceneID)
+            uiRuntime.sceneCaptureRegistrationsBySceneID.removeValue(forKey: sceneID)
+            uiRuntime.sceneCaptureLastKnownStateBySceneID.removeValue(forKey: sceneID)
             refreshSceneAggregateRecordingState()
         }
     }
@@ -180,9 +180,9 @@ extension ListenerManagerService {
 extension ListenerManagerService {
     func updateScreenRecordingStateIfChanged(isActive: Bool) {
         var event = NIDEvent(type: .screenRecording)
-        if NeuroIDCore.shared.screenCaptureLastKnownState == nil {
+        if uiRuntime.screenCaptureLastKnownState == nil {
             // first observation — only emit if already active to avoid a spurious "inactive" on cold start
-            NeuroIDCore.shared.screenCaptureLastKnownState = isActive
+            uiRuntime.screenCaptureLastKnownState = isActive
             if isActive {
                 event.attrs = [Attrs(n: "state", v: "active")]
                 captureEvent(event: event)
@@ -190,8 +190,8 @@ extension ListenerManagerService {
             return
         }
         // dedupe — multiple scenes can converge on the same state
-        guard NeuroIDCore.shared.screenCaptureLastKnownState != isActive else { return }
-        NeuroIDCore.shared.screenCaptureLastKnownState = isActive
+        guard uiRuntime.screenCaptureLastKnownState != isActive else { return }
+        uiRuntime.screenCaptureLastKnownState = isActive
         event.attrs = [Attrs(n: "state", v: isActive ? "active" : "inactive")]
         captureEvent(event: event)
     }
@@ -199,7 +199,7 @@ extension ListenerManagerService {
     @available(iOS 17.0, *)
     func refreshSceneAggregateRecordingState() {
         // any one scene capturing = device is recording
-        let isActive = NeuroIDCore.shared.sceneCaptureLastKnownStateBySceneID.values.contains(true)
+        let isActive = uiRuntime.sceneCaptureLastKnownStateBySceneID.values.contains(true)
         updateScreenRecordingStateIfChanged(isActive: isActive)
     }
 }

--- a/Source/NeuroID/UIRuntime.swift
+++ b/Source/NeuroID/UIRuntime.swift
@@ -5,13 +5,16 @@
 
 import Foundation
 
-@MainActor final class UIRuntime {
+@MainActor
+final class UIRuntime {
 
     var sceneCaptureRegistrationsBySceneID: [String: AnyObject] = [:]
     var sceneCaptureLastKnownStateBySceneID: [String: Bool] = [:]
     var screenCaptureLastKnownState: Bool?
 
-    nonisolated init() {}
+    nonisolated init() {
+        // init should not be isolated so NeuroIDCore can start it
+    }
 
     func resetScreenCaptureTrackingState() {
         sceneCaptureRegistrationsBySceneID.removeAll()

--- a/Source/NeuroID/UIRuntime.swift
+++ b/Source/NeuroID/UIRuntime.swift
@@ -1,0 +1,21 @@
+//
+//  UIRuntime.swift
+//  NeuroID
+//
+
+import Foundation
+
+@MainActor final class UIRuntime {
+
+    var sceneCaptureRegistrationsBySceneID: [String: AnyObject] = [:]
+    var sceneCaptureLastKnownStateBySceneID: [String: Bool] = [:]
+    var screenCaptureLastKnownState: Bool?
+
+    nonisolated init() {}
+
+    func resetScreenCaptureTrackingState() {
+        sceneCaptureRegistrationsBySceneID.removeAll()
+        sceneCaptureLastKnownStateBySceneID.removeAll()
+        screenCaptureLastKnownState = nil
+    }
+}


### PR DESCRIPTION
This PR introduces UIRuntime on `@MainActor` and moves screen capture/recording state into it. The goal is to keep UI mutable state in a main-actor-isolated boundary instead of `NeuroIDCore`, which is not `@MainActor`-isolated, reducing actor/thread-safety risk. `NeuroIDCore` and services now coordinate with UIRuntime as needed.

This PR only migrates screen capture/recording state; additional UI state will move in follow-up PRs.

Fixes the build workflow to boot the correct simulator before build/testing.

[ENG-11756]

[ENG-11756]: https://neuro-id.atlassian.net/browse/ENG-11756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ