### PR TITLE
[ENG-11756] Isolate start functions and swizzle state to main actor

### DIFF
--- a/SDKTest/NeuroIDClass/MultiAppFlowTests.swift
+++ b/SDKTest/NeuroIDClass/MultiAppFlowTests.swift
@@ -9,6 +9,7 @@ import XCTest
 
 @testable import NeuroID
 
+@MainActor
 class MultiAppFlowTests: XCTestCase {
     let clientKey = "key_test_0OMmplsawAp2CQfWrytWA3wL"
 

--- a/Source/NeuroID/NeuroID.swift
+++ b/Source/NeuroID/NeuroID.swift
@@ -106,6 +106,7 @@ public enum NeuroID {
     }
 
     // SESSION FUNCTIONS
+    @MainActor
     public static func start(
         completion: @escaping (Bool) -> Void = { _ in }
     ) {
@@ -116,6 +117,7 @@ public enum NeuroID {
         return NeuroIDCore.shared.stop()
     }
 
+    @MainActor
     public static func startSession(
         _ sessionID: String? = nil,
         completion: @escaping (SessionStartResult) -> Void = { _ in }
@@ -144,6 +146,7 @@ public enum NeuroID {
        throughout the rest of the session
       i.e. start/startSession/startAppFlow -> startAppFlow("site2") -> stop/stopSession
      */
+    @MainActor
     public static func startAppFlow(
         siteID: String,
         sessionID: String? = nil,
@@ -153,6 +156,7 @@ public enum NeuroID {
     }
 
     // AdvancedDevice Functions
+    @MainActor
     public static func start(
         _ advancedDeviceSignals: Bool,
         completion: @escaping (Bool) -> Void = { _ in }
@@ -160,6 +164,7 @@ public enum NeuroID {
         NeuroIDCore.shared.start(advancedDeviceSignals, completion: completion)
     }
 
+    @MainActor
     public static func startSession(
         _ sessionID: String? = nil,
         _ advancedDeviceSignals: Bool,

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension NeuroIDCore {
+    @MainActor
     func start(
         _ advancedDeviceSignals: Bool,
         completion: @escaping (Bool) -> Void = { _ in }
@@ -23,6 +24,7 @@ extension NeuroIDCore {
         }
     }
 
+    @MainActor
     func startSession(
         _ sessionID: String? = nil,
         _ advancedDeviceSignals: Bool,

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -59,6 +59,7 @@ extension NeuroIDCore {
        throughout the rest of the session
       i.e. start/startSession/startAppFlow -> startAppFlow("site2") -> stop/stopSession
      */
+    @MainActor
     func startAppFlow(
         siteID: String,
         sessionID: String? = nil,
@@ -251,6 +252,7 @@ extension NeuroIDCore {
      - Will move queued events into main queue
      - Will make call to check/capture ADV event
      */
+    @MainActor
     func setupSession(
         siteID: String?,
         customFunctionality: @escaping () -> Void = {},
@@ -266,7 +268,7 @@ extension NeuroIDCore {
         self.setupListeners()
 
         self.createSession()
-        self.swizzle()
+        self.uiRuntime.swizzle()
 
         // custom functionality = the different timer starts (start vs. startSession)
         //  this will be refactored once we bring start/startSession in alignment
@@ -280,6 +282,7 @@ extension NeuroIDCore {
     }
 
     // Internal implementation that allows a siteID
+    @MainActor
     func start(
         siteID: String?,
         completion: @escaping (Bool) -> Void = { _ in }
@@ -313,6 +316,7 @@ extension NeuroIDCore {
     }
 
     // Internal implementation that allows a siteID
+    @MainActor
     func startSession(
         siteID: String?,
         sessionID: String? = nil,

--- a/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
@@ -98,7 +98,6 @@ class NeuroIDCore: NSObject {
 
     var observingInputs = false
     var observingKeyboard = false
-    var didSwizzle: Bool = false
 
     public static var registeredTargets = [String]()
 
@@ -282,20 +281,6 @@ class NeuroIDCore: NSObject {
 
     func isStopped() -> Bool {
         return self._isSDKStarted != true
-    }
-
-    func swizzle() {
-        if self.didSwizzle {
-            return
-        }
-
-        UIViewController.startSwizzling()
-        UITextField.startSwizzling()
-        UITextView.startSwizzling()
-        UINavigationController.swizzleNavigation()
-        UITableView.tableviewSwizzle()
-
-        self.didSwizzle.toggle()
     }
 
     /// Get the current SDK version from bundle

--- a/Source/NeuroID/UIRuntime.swift
+++ b/Source/NeuroID/UIRuntime.swift
@@ -3,10 +3,12 @@
 //  NeuroID
 //
 
-import Foundation
+import UIKit
 
 @MainActor
 final class UIRuntime {
+
+    var didSwizzle: Bool = false
 
     var sceneCaptureRegistrationsBySceneID: [String: AnyObject] = [:]
     var sceneCaptureLastKnownStateBySceneID: [String: Bool] = [:]
@@ -20,5 +22,17 @@ final class UIRuntime {
         sceneCaptureRegistrationsBySceneID.removeAll()
         sceneCaptureLastKnownStateBySceneID.removeAll()
         screenCaptureLastKnownState = nil
+    }
+
+    func swizzle() {
+        guard !didSwizzle else { return }
+
+        UIViewController.startSwizzling()
+        UITextField.startSwizzling()
+        UITextView.startSwizzling()
+        UINavigationController.swizzleNavigation()
+        UITableView.tableviewSwizzle()
+
+        didSwizzle = true
     }
 }


### PR DESCRIPTION
Moves the swizzle invocation into the `UIRuntime` class. The goal is to keep UI related mutable state in a main-actor-isolated boundary instead of NeuroIDCore, which is not @MainActor-isolated, reducing actor/thread-safety risk.

Also, in pursuit of that isolation, we now we explicitly require `start`, `startSession`, and `startAppFlow` to be called from the `@MainActor`. This should not be a change for any integrators because they should be calling these functions from main anyways.

[ENG-11756]

[ENG-11756]: https://neuro-id.atlassian.net/browse/ENG-11756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ