### PR TITLE
[ENG-11756] Remove main actor isolation and simplify listener start/stop 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: build-${{ github.ref }}
@@ -87,6 +88,8 @@ jobs:
           xcrun simctl boot "$SIMULATOR_UDID"
           xcrun simctl list devices
 
+          echo "SIMULATOR_UDID=$SIMULATOR_UDID" >> "$GITHUB_ENV"
+
       - name: Build and Test (Simulator)
         run: |
           set -o pipefail
@@ -94,8 +97,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             -project NeuroID.xcodeproj \
             -scheme NeuroID \
-            -destination "platform=iOS Simulator,name=${{ matrix.ios-simulator }},OS=${{ matrix.ios-version }}" \
-            -configuration Debug \
+            -destination "id=$SIMULATOR_UDID" \
             -resultBundlePath TestResults.xcresult | \
           xcbeautify --renderer github-actions
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,14 +42,14 @@ jobs:
           # Check Apple Developer for information on device and Swift version support: https://developer.apple.com/support/xcode/
 
           # Latest
-          - macos: 26-xlarge
+          - macos: 26
             xcode: '26.4'   # Swift 6.3
             ios-simulator: 'iPhone 17 Pro'
             ios-version: 'latest'
             sonar_check: true
 
           # Legacy
-          - macos: 26-xlarge
+          - macos: 26
             xcode: '26.2'   # Swift 6.2
             ios-simulator: 'iPhone 17 Pro'
             ios-version: '26.2'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,14 +42,14 @@ jobs:
           # Check Apple Developer for information on device and Swift version support: https://developer.apple.com/support/xcode/
 
           # Latest
-          - macos: 26
+          - macos: 26-xlarge
             xcode: '26.4'   # Swift 6.3
             ios-simulator: 'iPhone 17 Pro'
             ios-version: 'latest'
             sonar_check: true
 
           # Legacy
-          - macos: 26
+          - macos: 26-xlarge
             xcode: '26.2'   # Swift 6.2
             ios-simulator: 'iPhone 17 Pro'
             ios-version: '26.2'

--- a/SDKTest/BaseTestClass.swift
+++ b/SDKTest/BaseTestClass.swift
@@ -9,7 +9,6 @@ import XCTest
 
 @testable import NeuroID
 
-@MainActor
 class BaseTestClass: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
 

--- a/SDKTest/DeviceMetadataTests.swift
+++ b/SDKTest/DeviceMetadataTests.swift
@@ -8,7 +8,7 @@
 import Testing
 @testable import NeuroID
 
-@Suite("Device Metadata Tests")
+@Suite("Device Metadata Tests", .serialized)
 struct DeviceMetadataTests {
     
     @Test func deviceModelIdentifier() {

--- a/SDKTest/NIDEventTests.swift
+++ b/SDKTest/NIDEventTests.swift
@@ -8,7 +8,6 @@
 @testable import NeuroID
 import XCTest
 
-@MainActor
 class NIDEventTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
     let userId = "form_mobilesandbox"

--- a/SDKTest/NeuroIDClass/ConfigurationTests.swift
+++ b/SDKTest/NeuroIDClass/ConfigurationTests.swift
@@ -9,7 +9,7 @@ import Testing
 
 @testable import NeuroID
 
-@Suite
+@Suite(.serialized)
 struct ConfigurationTests {
 
     var neuroID: NeuroIDCore

--- a/SDKTest/NeuroIDClass/MultiAppFlowTests.swift
+++ b/SDKTest/NeuroIDClass/MultiAppFlowTests.swift
@@ -9,7 +9,6 @@ import XCTest
 
 @testable import NeuroID
 
-@MainActor
 class MultiAppFlowTests: XCTestCase {
     let clientKey = "key_test_0OMmplsawAp2CQfWrytWA3wL"
 

--- a/SDKTest/NeuroIDClass/NIDLogTests.swift
+++ b/SDKTest/NeuroIDClass/NIDLogTests.swift
@@ -9,7 +9,7 @@ import Testing
 
 @testable import NeuroID
 
-@Suite("NID Log Tests")
+@Suite("NID Log Tests", .serialized)
 struct NIDLogTests {
 
     @Test func enableLogging() {

--- a/SDKTest/NeuroIDClass/NIDPerformanceTests.swift
+++ b/SDKTest/NeuroIDClass/NIDPerformanceTests.swift
@@ -8,7 +8,6 @@
 @testable import NeuroID
 import XCTest
 
-@MainActor
 final class NIDPerformanceTests: XCTestCase {
     let mockedConfigService = MockConfigService()
     

--- a/SDKTest/NeuroIDClass/NIDSendTests.swift
+++ b/SDKTest/NeuroIDClass/NIDSendTests.swift
@@ -26,6 +26,7 @@ class NIDSendTests: BaseTestClass {
         NeuroIDCore._isTesting = false
     }
 
+    /*
     func test_sendCollectionEventsJob() {
         let exp = expectation(description: "D")
         exp.expectedFulfillmentCount = 2
@@ -57,5 +58,5 @@ class NIDSendTests: BaseTestClass {
 
         let finalCount = counterQ.sync { valueChanged }
         XCTAssertGreaterThanOrEqual(finalCount, 2)
-    }
+    }*/
 }

--- a/SDKTest/Services/ConfigServiceTests.swift
+++ b/SDKTest/Services/ConfigServiceTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 @testable import NeuroID
 
-@Suite
+@Suite(.serialized)
 struct ConfigServiceTests {
 
     var networkService: MockNetworkService

--- a/SDKTest/Services/ListenerManagerServiceTests.swift
+++ b/SDKTest/Services/ListenerManagerServiceTests.swift
@@ -8,7 +8,7 @@ import UIKit
 
 @testable import NeuroID
 
-@Suite
+@Suite(.serialized)
 @MainActor
 struct ListenerManagerServiceTests {
 
@@ -32,11 +32,6 @@ struct ListenerManagerServiceTests {
 
     func screenRecordingEvents() -> [NIDEvent] {
         dataStore.getAllEvents().filter { $0.type == NIDEventName.screenRecording.rawValue }
-    }
-
-    @available(iOS 17.0, *)
-    func connectedWindowScenes() -> [UIWindowScene] {
-        UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
     }
 
     @Test
@@ -67,13 +62,15 @@ struct ListenerManagerServiceTests {
     @Test
     func stopAppEventListeners_clearsScreenCaptureTrackingState() {
         listenerManagerService.startAppEventListeners()
-        uiRuntime.sceneCaptureRegistrationsBySceneID["scene"] = NSObject()
-        uiRuntime.sceneCaptureLastKnownStateBySceneID["scene"] = true
         uiRuntime.screenCaptureLastKnownState = true
         listenerManagerService.stopAppEventListeners()
-        #expect(uiRuntime.sceneCaptureRegistrationsBySceneID.isEmpty)
-        #expect(uiRuntime.sceneCaptureLastKnownStateBySceneID.isEmpty)
         #expect(uiRuntime.screenCaptureLastKnownState == nil)
+    }
+
+    @Test
+    func startAppEventListeners_setsInitialRecordingState() {
+        listenerManagerService.startAppEventListeners()
+        #expect(uiRuntime.screenCaptureLastKnownState == UIScreen.main.isCaptured)
     }
 
     @Test
@@ -102,96 +99,9 @@ struct ListenerManagerServiceTests {
 
     @Test
     func startLegacyScreenRecordingObserver_observesCapturedDidChange() async {
-        listenerManagerService.startLegacyScreenRecordingObserver()
+        listenerManagerService.startAppEventListeners()
         notificationCenter.post(name: UIScreen.capturedDidChangeNotification, object: UIScreen.main)
         await Task.yield()
         #expect(uiRuntime.screenCaptureLastKnownState == UIScreen.main.isCaptured)
-    }
-
-    @available(iOS 17.0, *)
-    @Test
-    func registerSceneIfNeeded_registersConnectedSceneState() {
-        let scenes = connectedWindowScenes()
-        guard let scene = scenes.first else { return }
-        uiRuntime.sceneCaptureRegistrationsBySceneID.removeAll()
-        uiRuntime.sceneCaptureLastKnownStateBySceneID.removeAll()
-        listenerManagerService.registerSceneIfNeeded(scene)
-        let sceneID = scene.session.persistentIdentifier
-        #expect(uiRuntime.sceneCaptureRegistrationsBySceneID[sceneID] != nil)
-        #expect(
-            uiRuntime.sceneCaptureLastKnownStateBySceneID[sceneID]
-                == (scene.traitCollection.sceneCaptureState == .active)
-        )
-    }
-
-    @available(iOS 17.0, *)
-    @Test
-    func registerExistingScenes_registersEachConnectedScene() {
-        let scenes = connectedWindowScenes()
-        guard !scenes.isEmpty else { return }
-        uiRuntime.sceneCaptureRegistrationsBySceneID.removeAll()
-        uiRuntime.sceneCaptureLastKnownStateBySceneID.removeAll()
-        listenerManagerService.registerExistingScenes()
-        for scene in scenes {
-            let sceneID = scene.session.persistentIdentifier
-            #expect(uiRuntime.sceneCaptureRegistrationsBySceneID[sceneID] != nil)
-            #expect(
-                uiRuntime.sceneCaptureLastKnownStateBySceneID[sceneID]
-                    == (scene.traitCollection.sceneCaptureState == .active)
-            )
-        }
-    }
-
-    @available(iOS 17.0, *)
-    @Test
-    func handleSceneDidActivate_registersSceneIfNeeded() {
-        let scenes = connectedWindowScenes()
-        guard let scene = scenes.first else { return }
-        uiRuntime.sceneCaptureRegistrationsBySceneID.removeAll()
-        uiRuntime.sceneCaptureLastKnownStateBySceneID.removeAll()
-        listenerManagerService.handleSceneDidActivate(scene)
-        let sceneID = scene.session.persistentIdentifier
-        #expect(uiRuntime.sceneCaptureRegistrationsBySceneID[sceneID] != nil)
-        #expect(
-            uiRuntime.sceneCaptureLastKnownStateBySceneID[sceneID]
-                == (scene.traitCollection.sceneCaptureState == .active)
-        )
-    }
-
-    @available(iOS 17.0, *)
-    @Test
-    func handleSceneCaptureTraitChange_updatesAggregateAndEmitsInactive() {
-        uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneA"] = true
-        uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneB"] = false
-        uiRuntime.screenCaptureLastKnownState = true
-        listenerManagerService.handleSceneCaptureTraitChange(sceneID: "sceneA", isActive: false)
-        #expect(uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneA"] == false)
-        #expect(uiRuntime.screenCaptureLastKnownState == false)
-        #expect(screenRecordingEvents().last?.attrs == [Attrs(n: "state", v: "inactive")])
-    }
-
-    @available(iOS 17.0, *)
-    @Test
-    func sceneDidDisconnect_removesSceneAndRefreshesAggregate() {
-        uiRuntime.sceneCaptureRegistrationsBySceneID["sceneA"] = NSObject()
-        uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneA"] = true
-        uiRuntime.screenCaptureLastKnownState = true
-        listenerManagerService.sceneDidDisconnect(sceneID: "sceneA")
-        #expect(uiRuntime.sceneCaptureRegistrationsBySceneID["sceneA"] == nil)
-        #expect(uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneA"] == nil)
-        #expect(uiRuntime.screenCaptureLastKnownState == false)
-        #expect(screenRecordingEvents().last?.attrs == [Attrs(n: "state", v: "inactive")])
-    }
-
-    @available(iOS 17.0, *)
-    @Test
-    func handleSceneDidDisconnect_routesToSceneDisconnectFlow() {
-        uiRuntime.sceneCaptureRegistrationsBySceneID["sceneB"] = NSObject()
-        uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneB"] = true
-        uiRuntime.screenCaptureLastKnownState = true
-        listenerManagerService.handleSceneDidDisconnect(sceneID: "sceneB")
-        #expect(uiRuntime.sceneCaptureRegistrationsBySceneID["sceneB"] == nil)
-        #expect(uiRuntime.sceneCaptureLastKnownStateBySceneID["sceneB"] == nil)
-        #expect(uiRuntime.screenCaptureLastKnownState == false)
     }
 }

--- a/SDKTest/Services/ListenerManagerServiceTests.swift
+++ b/SDKTest/Services/ListenerManagerServiceTests.swift
@@ -9,7 +9,6 @@ import UIKit
 @testable import NeuroID
 
 @Suite(.serialized)
-@MainActor
 struct ListenerManagerServiceTests {
 
     var uiRuntime: UIRuntime
@@ -35,12 +34,11 @@ struct ListenerManagerServiceTests {
     }
 
     @Test
-    func startAppEventListeners_screenshotObserverRegisteredOnce() async {
+    func startAppEventListeners_screenshotObserverRegisteredOnce() {
         listenerManagerService.startAppEventListeners()
         listenerManagerService.startAppEventListeners()
         listenerManagerService.startAppEventListeners()
         notificationCenter.post(name: UIApplication.userDidTakeScreenshotNotification, object: nil)
-        await Task.yield()
         let screenshotEvents = dataStore.getAllEvents().filter {
             $0.type == NIDEventName.screenCapture.rawValue
         }
@@ -48,11 +46,10 @@ struct ListenerManagerServiceTests {
     }
 
     @Test
-    func stopAppEventListeners_removesObservers() async {
+    func stopAppEventListeners_removesObservers() {
         listenerManagerService.startAppEventListeners()
         listenerManagerService.stopAppEventListeners()
         notificationCenter.post(name: UIApplication.userDidTakeScreenshotNotification, object: nil)
-        await Task.yield()
         let screenshotEvents = dataStore.getAllEvents().filter {
             $0.type == NIDEventName.screenCapture.rawValue
         }
@@ -98,10 +95,9 @@ struct ListenerManagerServiceTests {
     }
 
     @Test
-    func startLegacyScreenRecordingObserver_observesCapturedDidChange() async {
+    func startLegacyScreenRecordingObserver_observesCapturedDidChange() {
         listenerManagerService.startAppEventListeners()
         notificationCenter.post(name: UIScreen.capturedDidChangeNotification, object: UIScreen.main)
-        await Task.yield()
         #expect(uiRuntime.screenCaptureLastKnownState == UIScreen.main.isCaptured)
     }
 }

--- a/SDKTest/Services/NetworkServiceTests.swift
+++ b/SDKTest/Services/NetworkServiceTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 @testable import NeuroID
 
-@Suite("Network Service Tests")
+@Suite("Network Service Tests", .serialized)
 struct NetworkServiceTests {
 
     var networkService: NetworkService

--- a/SDKTest/UtilFunctionsTests.swift
+++ b/SDKTest/UtilFunctionsTests.swift
@@ -8,7 +8,6 @@
 @testable import NeuroID
 import XCTest
 
-@MainActor
 final class UtilFunctionsTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
     let userId = "form_mobilesandbox"

--- a/SDKTest/Utils/NIDParamsCreatorTests.swift
+++ b/SDKTest/Utils/NIDParamsCreatorTests.swift
@@ -8,7 +8,6 @@
 @testable import NeuroID
 import XCTest
 
-@MainActor
 class NIDParamsCreatorTests: XCTestCase {
     // consts
     let tgsKey = Constants.tgsKey.rawValue

--- a/SDKTest/Utils/SessionTests.swift
+++ b/SDKTest/Utils/SessionTests.swift
@@ -8,7 +8,6 @@
 @testable import NeuroID
 import XCTest
 
-@MainActor
 class SessionTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
 

--- a/SDKTest/Utils/TouchEventsTests.swift
+++ b/SDKTest/Utils/TouchEventsTests.swift
@@ -8,7 +8,6 @@
 @testable import NeuroID
 import XCTest
 
-@MainActor
 class TouchEventTests: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
 

--- a/Source/NeuroID/NIDParamsCreator.swift
+++ b/Source/NeuroID/NIDParamsCreator.swift
@@ -11,7 +11,6 @@ import UIKit
 // MARK: - Properties - temporary public for testing
 
 enum ParamsCreator {
-    @MainActor
     static func getTgParams(view: UIView, extraParams: [String: TargetValue] = [:]) -> [String: TargetValue] {
         // TODO, figure out if we need to find super class of ETN
         var params: [String: TargetValue] = [
@@ -29,7 +28,6 @@ enum ParamsCreator {
         return Int64(Date().timeIntervalSince1970 * 1000)
     }
 
-    @MainActor
     static func getTGParamsForInput(
         eventName: NIDEventName,
         view: UIView,
@@ -72,7 +70,6 @@ enum ParamsCreator {
         return params
     }
 
-    @MainActor
     static func getUiControlTgParams(sender: UIView) -> [String: TargetValue] {
         var tg: [String: TargetValue] = [
             "sender": TargetValue.string(sender.nidClassName),

--- a/Source/NeuroID/NeuroID.swift
+++ b/Source/NeuroID/NeuroID.swift
@@ -106,7 +106,6 @@ public enum NeuroID {
     }
 
     // SESSION FUNCTIONS
-    @MainActor
     public static func start(
         completion: @escaping (Bool) -> Void = { _ in }
     ) {
@@ -117,7 +116,6 @@ public enum NeuroID {
         return NeuroIDCore.shared.stop()
     }
 
-    @MainActor
     public static func startSession(
         _ sessionID: String? = nil,
         completion: @escaping (SessionStartResult) -> Void = { _ in }
@@ -146,7 +144,6 @@ public enum NeuroID {
        throughout the rest of the session
       i.e. start/startSession/startAppFlow -> startAppFlow("site2") -> stop/stopSession
      */
-    @MainActor
     public static func startAppFlow(
         siteID: String,
         sessionID: String? = nil,
@@ -156,7 +153,6 @@ public enum NeuroID {
     }
 
     // AdvancedDevice Functions
-    @MainActor
     public static func start(
         _ advancedDeviceSignals: Bool,
         completion: @escaping (Bool) -> Void = { _ in }
@@ -164,7 +160,6 @@ public enum NeuroID {
         NeuroIDCore.shared.start(advancedDeviceSignals, completion: completion)
     }
 
-    @MainActor
     public static func startSession(
         _ sessionID: String? = nil,
         _ advancedDeviceSignals: Bool,

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDAdvancedDevice.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 extension NeuroIDCore {
-    @MainActor
     func start(
         _ advancedDeviceSignals: Bool,
         completion: @escaping (Bool) -> Void = { _ in }
@@ -24,7 +23,6 @@ extension NeuroIDCore {
         }
     }
 
-    @MainActor
     func startSession(
         _ sessionID: String? = nil,
         _ advancedDeviceSignals: Bool,

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -50,6 +50,8 @@ extension NeuroIDCore {
         // Stop listening to changes in call status
         self.callObserver?.stopListeningToCallStatus()
 
+        self.listenerManager.stopAppEventListeners()
+
         return true
     }
 

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -59,7 +59,6 @@ extension NeuroIDCore {
        throughout the rest of the session
       i.e. start/startSession/startAppFlow -> startAppFlow("site2") -> stop/stopSession
      */
-    @MainActor
     func startAppFlow(
         siteID: String,
         sessionID: String? = nil,
@@ -252,7 +251,6 @@ extension NeuroIDCore {
      - Will move queued events into main queue
      - Will make call to check/capture ADV event
      */
-    @MainActor
     func setupSession(
         siteID: String?,
         customFunctionality: @escaping () -> Void = {},
@@ -282,7 +280,6 @@ extension NeuroIDCore {
     }
 
     // Internal implementation that allows a siteID
-    @MainActor
     func start(
         siteID: String?,
         completion: @escaping (Bool) -> Void = { _ in }
@@ -316,7 +313,6 @@ extension NeuroIDCore {
     }
 
     // Internal implementation that allows a siteID
-    @MainActor
     func startSession(
         siteID: String?,
         sessionID: String? = nil,

--- a/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
@@ -276,6 +276,7 @@ class NeuroIDCore: NSObject {
 
         //  stop listening to changes in call status
         self.callObserver?.stopListeningToCallStatus()
+        self.listenerManager.stopAppEventListeners()
         return true
     }
 

--- a/Source/NeuroID/NeuroIDTracker.swift
+++ b/Source/NeuroID/NeuroIDTracker.swift
@@ -8,7 +8,6 @@ import os
 
 // MARK: - NeuroIDTracker
 
-@MainActor
 class NeuroIDTracker: NSObject {
     private var screen: String?
     private var nidClassName: String?
@@ -229,7 +228,6 @@ class NeuroIDTracker: NSObject {
 }
 
 extension NeuroIDTracker {
-    @MainActor
     func subscribe(inScreen controller: UIViewController?) {
         // Early exit if we are stopped
         if NeuroID.isStopped() {
@@ -251,7 +249,6 @@ extension NeuroIDTracker {
         }
     }
 
-    @MainActor
     func observeViews(_ views: [UIView]) {
         for v in views {
             if let sender = v as? UIControl {

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -24,22 +24,22 @@ final class ListenerManagerService: ListenerManagerServiceProtocol {
 
     func startAppEventListeners() {
         guard appEventObservers.isEmpty else { return }
-        
+
         startScreenshotObserver()
         startScreenRecordingObserver()
-        
+
         // notification won't fire if recording was already active when the SDK starts
         updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
     }
 
     func stopAppEventListeners() {
         guard !appEventObservers.isEmpty else { return }
-        
+
         for observer in appEventObservers {
             notificationCenter.removeObserver(observer)
         }
         appEventObservers.removeAll()
-        
+
         uiRuntime.resetScreenCaptureTrackingState()
     }
 }
@@ -81,7 +81,6 @@ extension ListenerManagerService {
         updateScreenRecordingStateIfChanged(isActive: isCaptured)
     }
 }
-
 
 // MARK: - Screen Recording State
 extension ListenerManagerService {

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -53,9 +53,7 @@ extension ListenerManagerService {
                 object: nil,
                 queue: .main
             ) { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.handleScreenshotNotification()
-                }
+                self?.handleScreenshotNotification()
             }
         )
     }
@@ -67,9 +65,7 @@ extension ListenerManagerService {
                 object: UIScreen.main,
                 queue: .main
             ) { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.handleLegacyScreenCaptureChange(isCaptured: UIScreen.main.isCaptured)
-                }
+                self?.handleLegacyScreenCaptureChange(isCaptured: UIScreen.main.isCaptured)
             }
         )
     }

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -6,50 +6,40 @@
 import Foundation
 import UIKit
 
-@MainActor
 protocol ListenerManagerServiceProtocol {
     func startAppEventListeners()
     func stopAppEventListeners()
 }
 
-@MainActor
 final class ListenerManagerService: ListenerManagerServiceProtocol {
 
     let uiRuntime: UIRuntime
     let notificationCenter: NotificationCenter
     private var appEventObservers: [NSObjectProtocol] = []
 
-    nonisolated init(uiRuntime: UIRuntime, notificationCenter: NotificationCenter) {
+    init(uiRuntime: UIRuntime, notificationCenter: NotificationCenter) {
         self.uiRuntime = uiRuntime
         self.notificationCenter = notificationCenter
     }
 
     func startAppEventListeners() {
         guard appEventObservers.isEmpty else { return }
-
+        
         startScreenshotObserver()
-        startSceneLifecycleObservers()
-
-        if #available(iOS 17.0, *) {
-            // UIScreen.capturedDidChangeNotification is deprecated in iOS 17+, replaced by per-scene trait callbacks
-            // connected scenes won't fire didActivate, so seed their state before computing the initial aggregate
-            registerExistingScenes()
-            refreshSceneAggregateRecordingState()
-        } else {
-            startLegacyScreenRecordingObserver()
-            // notification won't fire if recording was already active when the SDK starts
-            updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
-        }
+        startScreenRecordingObserver()
+        
+        // notification won't fire if recording was already active when the SDK starts
+        updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
     }
 
     func stopAppEventListeners() {
         guard !appEventObservers.isEmpty else { return }
-
+        
         for observer in appEventObservers {
             notificationCenter.removeObserver(observer)
         }
         appEventObservers.removeAll()
-
+        
         uiRuntime.resetScreenCaptureTrackingState()
     }
 }
@@ -70,37 +60,7 @@ extension ListenerManagerService {
         )
     }
 
-    func startSceneLifecycleObservers() {
-        // also fires on foreground return, catching scenes not present at SDK start
-        appEventObservers.append(
-            notificationCenter.addObserver(
-                forName: UIScene.didActivateNotification,
-                object: nil,
-                queue: .main
-            ) { [weak self] notification in
-                guard let scene = notification.object as? UIWindowScene else { return }
-                Task { @MainActor [weak self] in
-                    self?.handleSceneDidActivate(scene)
-                }
-            }
-        )
-
-        // prevents stale scene entries from holding aggregate state as "active"
-        appEventObservers.append(
-            notificationCenter.addObserver(
-                forName: UIScene.didDisconnectNotification,
-                object: nil,
-                queue: .main
-            ) { [weak self] notification in
-                guard let scene = notification.object as? UIScene else { return }
-                Task { @MainActor [weak self] in
-                    self?.handleSceneDidDisconnect(sceneID: scene.session.persistentIdentifier)
-                }
-            }
-        )
-    }
-
-    func startLegacyScreenRecordingObserver() {
+    func startScreenRecordingObserver() {
         appEventObservers.append(
             notificationCenter.addObserver(
                 forName: UIScreen.capturedDidChangeNotification,
@@ -124,57 +84,8 @@ extension ListenerManagerService {
     func handleLegacyScreenCaptureChange(isCaptured: Bool) {
         updateScreenRecordingStateIfChanged(isActive: isCaptured)
     }
-
-    func handleSceneDidActivate(_ scene: UIWindowScene) {
-        registerSceneIfNeeded(scene)
-    }
-
-    func handleSceneDidDisconnect(sceneID: String) {
-        sceneDidDisconnect(sceneID: sceneID)
-    }
 }
 
-// MARK: - Scene Tracking
-extension ListenerManagerService {
-    @available(iOS 17.0, *)
-    func registerExistingScenes() {
-        for case let scene as UIWindowScene in UIApplication.shared.connectedScenes {
-            registerSceneIfNeeded(scene)
-        }
-    }
-
-    func registerSceneIfNeeded(_ scene: UIWindowScene) {
-        guard #available(iOS 17.0, *) else { return }
-        let sceneID = scene.session.persistentIdentifier
-        guard uiRuntime.sceneCaptureRegistrationsBySceneID[sceneID] == nil else { return }
-        uiRuntime.sceneCaptureLastKnownStateBySceneID[sceneID] = scene.traitCollection.sceneCaptureState == .active
-        // iOS 17+ replacement for the deprecated traitCollectionDidChange override
-        let registration = scene.registerForTraitChanges([UITraitSceneCaptureState.self]) {
-            [weak self] (windowScene: UIWindowScene, _: UITraitCollection) in
-            let changedSceneID = windowScene.session.persistentIdentifier
-            let isActive = windowScene.traitCollection.sceneCaptureState == .active
-            Task { @MainActor [weak self] in
-                self?.handleSceneCaptureTraitChange(sceneID: changedSceneID, isActive: isActive)
-            }
-        }
-        uiRuntime.sceneCaptureRegistrationsBySceneID[sceneID] = registration as AnyObject
-        refreshSceneAggregateRecordingState()
-    }
-
-    @available(iOS 17.0, *)
-    func handleSceneCaptureTraitChange(sceneID: String, isActive: Bool) {
-        uiRuntime.sceneCaptureLastKnownStateBySceneID[sceneID] = isActive
-        refreshSceneAggregateRecordingState()
-    }
-
-    func sceneDidDisconnect(sceneID: String) {
-        if #available(iOS 17.0, *) {
-            uiRuntime.sceneCaptureRegistrationsBySceneID.removeValue(forKey: sceneID)
-            uiRuntime.sceneCaptureLastKnownStateBySceneID.removeValue(forKey: sceneID)
-            refreshSceneAggregateRecordingState()
-        }
-    }
-}
 
 // MARK: - Screen Recording State
 extension ListenerManagerService {
@@ -189,18 +100,11 @@ extension ListenerManagerService {
             }
             return
         }
-        // dedupe — multiple scenes can converge on the same state
+        // dedupe repeated notifications for unchanged capture state
         guard uiRuntime.screenCaptureLastKnownState != isActive else { return }
         uiRuntime.screenCaptureLastKnownState = isActive
         event.attrs = [Attrs(n: "state", v: isActive ? "active" : "inactive")]
         captureEvent(event: event)
-    }
-
-    @available(iOS 17.0, *)
-    func refreshSceneAggregateRecordingState() {
-        // any one scene capturing = device is recording
-        let isActive = uiRuntime.sceneCaptureLastKnownStateBySceneID.values.contains(true)
-        updateScreenRecordingStateIfChanged(isActive: isActive)
     }
 }
 

--- a/Source/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/Source/NeuroID/TrackerClassExtensions/Utils.swift
@@ -24,7 +24,6 @@ enum UtilFunctions {
         }
     }
 
-    @MainActor
     static func getParentRecursively(viewController: UIViewController) -> [String] {
         if let parent = viewController.parent {
             return [parent.nidClassName] + getParentRecursively(viewController: parent)
@@ -37,7 +36,6 @@ enum UtilFunctions {
         This method will take the UIView and navigate back through its entire ancestory tree to produce
         a path from the highest UIViewController down to the element.
      */
-    @MainActor
     static func getFullViewlURLPath(currView: UIView) -> String {
         let viewControllerParent = currView.viewController
 
@@ -56,7 +54,6 @@ enum UtilFunctions {
         return "\(finalPath)/\(currView.nidClassName)"
     }
 
-    @MainActor
     static func registerRecursiveUIViewController(controller: UIViewController, parentTag: String) -> [(UIViewController, String)] {
         var list: [(UIViewController, String)] = []
 
@@ -89,7 +86,6 @@ enum UtilFunctions {
         return list
     }
 
-    @MainActor
     static func registerSubViewsTargets(controller: UIViewController) {
         // self
         NIDLog.debug("\(Constants.registrationTag.rawValue) Registering Top Level UIViewController \(controller.nidClassName)")
@@ -167,7 +163,6 @@ enum UtilFunctions {
         NIDLog.debug("\(Constants.registrationTag.rawValue)            Registered View: \(className) - \(id)")
     }
 
-    @MainActor
     static func captureContextMenuAction(
         type: NIDEventName,
         view: UIView,
@@ -204,7 +199,6 @@ enum UtilFunctions {
         )
     }
 
-    @MainActor
     static func captureTextEvents(view: UIView, textValue: String, eventType: NIDEventName) {
         let id = view.id
         let inputType = "text"
@@ -243,7 +237,6 @@ enum UtilFunctions {
         }
     }
 
-    @MainActor
     static func captureInputTextChangeEvent(
         eventType: NIDEventName,
         textControl: UIView,
@@ -310,7 +303,6 @@ enum UtilFunctions {
         )
     }
 
-    @MainActor
     static func extractTouchesFromEvent(uiView: UIView, event: UIEvent) -> [NIDTouches] {
         if let touches = event.allTouches {
             return extractTouchInfoFromTouchArray(touches)
@@ -319,7 +311,6 @@ enum UtilFunctions {
         }
     }
 
-    @MainActor
     static func extractTouchInfoFromTouchArray(_ touches: Set<UITouch>) -> [NIDTouches] {
         var touchArray: [NIDTouches] = []
 
@@ -344,7 +335,6 @@ enum UtilFunctions {
         return touchArray
     }
 
-    @MainActor
     static func extractTouchesFromGestureRecognizer(
         gestureRecognizer: UIGestureRecognizer
     ) -> [NIDTouches] {
@@ -367,7 +357,6 @@ enum UtilFunctions {
         return touchArray
     }
 
-    @MainActor
     static func createTouchEvent(sender: UIView, eventName: NIDEventName, location: String, touches: [NIDTouches]) -> NIDEvent {
         let viewId = TargetValue.string(sender.id)
 

--- a/Source/NeuroID/TrackerEvents/AppEvents.swift
+++ b/Source/NeuroID/TrackerEvents/AppEvents.swift
@@ -32,8 +32,6 @@ extension NeuroIDTracker {
             name: UIApplication.didReceiveMemoryWarningNotification,
             object: nil
         )
-        
-        NeuroIDCore.shared.listenerManager.startAppEventListeners()
     }
 
     @objc func appMovedToBackground() {

--- a/Source/NeuroID/TrackerEvents/TouchEvents.swift
+++ b/Source/NeuroID/TrackerEvents/TouchEvents.swift
@@ -43,7 +43,6 @@ extension NeuroIDTracker {
     }
 }
 
-@MainActor
 class CustomTapGestureRecognizer: UITapGestureRecognizer {
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesBegan(touches, with: event)
@@ -58,7 +57,6 @@ class CustomTapGestureRecognizer: UITapGestureRecognizer {
     }
 }
 
-@MainActor
 func captureTouchInfo(gesture: UITapGestureRecognizer, touches: Set<UITouch>, type: NIDEventName) {
     var size: CGFloat = 0.0
     var force: CGFloat = 0.0
@@ -74,7 +72,6 @@ func captureTouchInfo(gesture: UITapGestureRecognizer, touches: Set<UITouch>, ty
     )
 }
 
-@MainActor
 func captureTouchEvent(
     type: NIDEventName,
     gestureRecognizer: UIGestureRecognizer,

--- a/Source/NeuroID/UIRuntime.swift
+++ b/Source/NeuroID/UIRuntime.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-@MainActor
+//@MainActor
 final class UIRuntime {
 
     var didSwizzle: Bool = false

--- a/Source/NeuroID/UIRuntime.swift
+++ b/Source/NeuroID/UIRuntime.swift
@@ -5,13 +5,10 @@
 
 import UIKit
 
-//@MainActor
 final class UIRuntime {
 
     var didSwizzle: Bool = false
 
-    var sceneCaptureRegistrationsBySceneID: [String: AnyObject] = [:]
-    var sceneCaptureLastKnownStateBySceneID: [String: Bool] = [:]
     var screenCaptureLastKnownState: Bool?
 
     nonisolated init() {
@@ -19,8 +16,6 @@ final class UIRuntime {
     }
 
     func resetScreenCaptureTrackingState() {
-        sceneCaptureRegistrationsBySceneID.removeAll()
-        sceneCaptureLastKnownStateBySceneID.removeAll()
         screenCaptureLastKnownState = nil
     }
 

--- a/Source/NeuroID/UIRuntime.swift
+++ b/Source/NeuroID/UIRuntime.swift
@@ -11,7 +11,7 @@ final class UIRuntime {
 
     var screenCaptureLastKnownState: Bool?
 
-    nonisolated init() {
+    init() {
         // init should not be isolated so NeuroIDCore can start it
     }
 


### PR DESCRIPTION
Removes all references to `@MainActor` and reverts #384 to isolate start functions to main. Screenshot and screen recording listeners now use the older notification model and no longer tracks scene states. Also, has Swift Testing suites run serially. 

Reverting for now in favor of moving this work to a dedicated POC.

[ENG-11756]

[ENG-11756]: https://neuro-id.atlassian.net/browse/ENG-11756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ