### PR TITLE
[ENG-11793] Update FingerprintPro from 2.13.0 to 2.14.0

### DIFF
--- a/NeuroID.podspec
+++ b/NeuroID.podspec
@@ -15,8 +15,8 @@ s.homepage = "https://neuro-id.com/"
 s.source = { :git => "https://github.com/Neuro-ID/neuroid-ios-sdk.git", :tag => "#{s.version}"}
 s.source_files = "Source/NeuroID/**/*.{h,c,m,swift,mlmodel,mlmodelc}"
 
-s.dependency 'Alamofire', '5.11.1'
-s.dependency 'FingerprintPro', '2.13.0'
+s.dependency 'Alamofire', '5.11.2'
+s.dependency 'FingerprintPro', '2.15.0'
 
 s.default_subspecs = 'Core'
 s.subspec 'Core' do |core|

--- a/NeuroID.podspec
+++ b/NeuroID.podspec
@@ -16,7 +16,7 @@ s.source = { :git => "https://github.com/Neuro-ID/neuroid-ios-sdk.git", :tag => 
 s.source_files = "Source/NeuroID/**/*.{h,c,m,swift,mlmodel,mlmodelc}"
 
 s.dependency 'Alamofire', '5.11.2'
-s.dependency 'FingerprintPro', '2.15.0'
+s.dependency 'FingerprintPro', '2.14.0'
 
 s.default_subspecs = 'Core'
 s.subspec 'Core' do |core|

--- a/NeuroID.xcodeproj/project.pbxproj
+++ b/NeuroID.xcodeproj/project.pbxproj
@@ -715,7 +715,7 @@
 			repositoryURL = "https://github.com/fingerprintjs/fingerprintjs-pro-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 2.13.0;
+				version = 2.15.0;
 			};
 		};
 		01D31F542E9D90CC0042B0DD /* XCRemoteSwiftPackageReference "JSONSchemaValidation" */ = {

--- a/NeuroID.xcodeproj/project.pbxproj
+++ b/NeuroID.xcodeproj/project.pbxproj
@@ -715,7 +715,7 @@
 			repositoryURL = "https://github.com/fingerprintjs/fingerprintjs-pro-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 2.15.0;
+				version = 2.14.0;
 			};
 		};
 		01D31F542E9D90CC0042B0DD /* XCRemoteSwiftPackageReference "JSONSchemaValidation" */ = {

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Alamofire/Alamofire.git", exact: "5.11.1"),
-        .package(url: "https://github.com/fingerprintjs/fingerprintjs-pro-ios", exact: "2.13.0"),
+        .package(url: "https://github.com/Alamofire/Alamofire.git", exact: "5.11.2"),
+        .package(url: "https://github.com/fingerprintjs/fingerprintjs-pro-ios", exact: "2.15.0"),
         .package(url: "https://github.com/dashpay/JSONSchemaValidation", from: "2.0.7"),
         .package(url: "https://github.com/kylef/JSONSchema.swift", from: "0.6.0")
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", exact: "5.11.2"),
-        .package(url: "https://github.com/fingerprintjs/fingerprintjs-pro-ios", exact: "2.15.0"),
+        .package(url: "https://github.com/fingerprintjs/fingerprintjs-pro-ios", exact: "2.14.0"),
         .package(url: "https://github.com/dashpay/JSONSchemaValidation", from: "2.0.7"),
         .package(url: "https://github.com/kylef/JSONSchema.swift", from: "0.6.0")
     ],


### PR DESCRIPTION
Update FingerprintPro from `2.13.0` to `2.14.0`. Also updates Alamofire to the latest version `5.11.2`.

[ENG-11793] 

[ENG-11793]: https://neuro-id.atlassian.net/browse/ENG-11793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ