### PR TITLE
[ENG-11582] Add workflow to tag release candidates

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,78 @@
+name: Cut Release Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      rc_number:
+        description: 'Release candidate number (e.g., 1 for 4.0.0-rc.1)'
+        required: true
+        type: number
+
+concurrency:
+  group: rc-release
+  cancel-in-progress: false
+
+jobs:
+  releaseCandidate:
+
+    name: Create Release from Tag
+
+    # Needs to run on macos to be able to run pod trunk push command
+    runs-on: macos-26
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate RC input
+        run: |
+          if [ ${{ inputs.rc_number }} -lt 1 ]; then
+            echo "Error: RC number must be a positive integer"
+            exit 1
+          fi
+
+      - name: Validate branch
+        run: |
+          BRANCH="${GITHUB_REF_NAME}"
+
+          if [ "$BRANCH" != "main" ]; then
+            echo "Error: This workflow must be run from main"
+            exit 1
+          fi
+
+      - name: Read SDK version
+        id: version
+        run: |
+          VERSION=$(grep 'static let nidVersion' Source/NeuroID/NeuroIDClass/NeuroIDCore.swift | sed -E 's/.*"([^"]+)".*/\1/')
+
+          if ! echo "$VERSION" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: Version format is invalid. Expected format: X.Y.Z"
+            exit 1
+          fi
+
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Tag Release Candidate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email developer@neuro-id.com
+          git config --global user.name neuroid-developer
+
+          TAG="${{ steps.version.outputs.VERSION }}-rc.${{ inputs.rc_number }}"
+
+          # Check if tag already exists in the remote repository
+          if git ls-remote --tags --exit-code origin "refs/tags/$TAG" >/dev/null; then
+            echo "Error: Tag $TAG already exists"
+            exit 1
+          fi
+
+          git tag -a "$TAG" -m "Release Candidate $TAG"
+          git push origin "$TAG"
+
+      - name: Release to Cocoapods
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: pod trunk push NeuroID.podspec --allow-warnings


### PR DESCRIPTION
Add workflow to tag release candidates and push them to CocoaPods for React Native.

[ENG-11582]

[ENG-11582]: https://neuro-id.atlassian.net/browse/ENG-11582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ