### PR TITLE
[ENG-11697] Simplify screen recording logic

### DIFF
--- a/SDKTest/Services/ListenerManagerServiceTests.swift
+++ b/SDKTest/Services/ListenerManagerServiceTests.swift
@@ -84,9 +84,9 @@ struct ListenerManagerServiceTests {
 
     @Test
     func handleLegacyScreenCaptureChange_updatesRecordingState() {
-        listenerManagerService.handleLegacyScreenCaptureChange(isCaptured: false)
-        listenerManagerService.handleLegacyScreenCaptureChange(isCaptured: true)
-        listenerManagerService.handleLegacyScreenCaptureChange(isCaptured: false)
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: true)
+        listenerManagerService.updateScreenRecordingStateIfChanged(isActive: false)
         let events = screenRecordingEvents()
         #expect(events.count == 2)
         #expect(events[0].attrs == [Attrs(n: "state", v: "active")])

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDListeners.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDListeners.swift
@@ -9,6 +9,8 @@ import Foundation
 
 extension NeuroIDCore {
     func setupListeners() {
+        self.listenerManager.startAppEventListeners()
+
         // We will always cancel the collection job and then recreate with new interval and start
         self.sendCollectionEventsJob.cancel()
         self.sendCollectionEventsJob = RepeatingTask(

--- a/Source/NeuroID/NeuroIDTracker.swift
+++ b/Source/NeuroID/NeuroIDTracker.swift
@@ -238,8 +238,6 @@ extension NeuroIDTracker {
             observeViews(views)
         }
 
-        NeuroIDCore.shared.listenerManager.startAppEventListeners()
-
         // Only run observations on first run
         if !NeuroIDCore.shared.observingInputs {
             NeuroIDCore.shared.observingInputs = true

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -53,7 +53,7 @@ extension ListenerManagerService {
                 object: nil,
                 queue: .main
             ) { [weak self] _ in
-                self?.handleScreenshotNotification()
+                self?.captureEvent(event: NIDEvent(type: .screenCapture))
             }
         )
     }
@@ -65,41 +65,29 @@ extension ListenerManagerService {
                 object: UIScreen.main,
                 queue: .main
             ) { [weak self] _ in
-                self?.handleLegacyScreenCaptureChange(isCaptured: UIScreen.main.isCaptured)
+                self?.updateScreenRecordingStateIfChanged(isActive: UIScreen.main.isCaptured)
             }
         )
-    }
-}
-
-// MARK: - Notification Handlers
-extension ListenerManagerService {
-    func handleScreenshotNotification() {
-        captureEvent(event: NIDEvent(type: .screenCapture))
-    }
-
-    func handleLegacyScreenCaptureChange(isCaptured: Bool) {
-        updateScreenRecordingStateIfChanged(isActive: isCaptured)
     }
 }
 
 // MARK: - Screen Recording State
 extension ListenerManagerService {
     func updateScreenRecordingStateIfChanged(isActive: Bool) {
-        var event = NIDEvent(type: .screenRecording)
-        if uiRuntime.screenCaptureLastKnownState == nil {
-            // first observation — only emit if already active to avoid a spurious "inactive" on cold start
-            uiRuntime.screenCaptureLastKnownState = isActive
-            if isActive {
-                event.attrs = [Attrs(n: "state", v: "active")]
-                captureEvent(event: event)
-            }
-            return
-        }
-        // dedupe repeated notifications for unchanged capture state
-        guard uiRuntime.screenCaptureLastKnownState != isActive else { return }
+        let previousState: Bool? = uiRuntime.screenCaptureLastKnownState
         uiRuntime.screenCaptureLastKnownState = isActive
-        event.attrs = [Attrs(n: "state", v: isActive ? "active" : "inactive")]
-        captureEvent(event: event)
+
+        guard previousState != isActive else { return }
+
+        // Only emit the initial observation if capture was already active
+        guard previousState != nil || isActive else { return }
+
+        captureEvent(
+            event: NIDEvent(
+                type: .screenRecording,
+                attrs: [Attrs(n: "state", v: isActive ? "active" : "inactive")]
+            )
+        )
     }
 }
 


### PR DESCRIPTION
Simplify screen recording logic and move the start screen recording/capture listeners out of NeuroIDTracker.

[ENG-11697]

[ENG-11697]: https://neuro-id.atlassian.net/browse/ENG-11697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ