### PR TITLE
[ENG-11615] Deprecate seperate advanced device functions

### DIFF
--- a/Source/NeuroID/NeuroID.swift
+++ b/Source/NeuroID/NeuroID.swift
@@ -155,13 +155,15 @@ public enum NeuroID {
     }
 
     // AdvancedDevice Functions
+    @available(*, deprecated)
     public static func start(
         _ advancedDeviceSignals: Bool,
         completion: @escaping (Bool) -> Void = { _ in }
     ) {
         NeuroIDCore.shared.start(advancedDeviceSignals, completion: completion)
     }
-
+    
+    @available(*, deprecated)
     public static func startSession(
         _ sessionID: String? = nil,
         _ advancedDeviceSignals: Bool,


### PR DESCRIPTION
Deprecate seperate advanced device functions:
- `start(_ advancedDeviceSignals:)`
- `startSession(_ sessionID:, _ advancedDeviceSignals:)`

[ENG-11615] 

[ENG-11615]: https://neuro-id.atlassian.net/browse/ENG-11615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ