### PR TITLE
[ENG-11808] Update call state tracking

### DIFF
--- a/SDKTest/Services/NIDCallStatusObserverService.swift
+++ b/SDKTest/Services/NIDCallStatusObserverService.swift
@@ -1,0 +1,304 @@
+//
+//  NIDCallStatusObserverService.swift
+//  NeuroID
+//
+
+import Foundation
+import Testing
+
+@testable import NeuroID
+
+@Suite
+struct NIDCallStatusObserverServiceTests {
+    var eventStorageService: MockEventStorageService
+    var configService: MockConfigService
+    var callService: NIDCallStatusObserverService
+
+    init() {
+        eventStorageService = MockEventStorageService()
+        configService = MockConfigService()
+        callService = NIDCallStatusObserverService(
+            eventStorageService: eventStorageService,
+            configService: configService
+        )
+    }
+
+    @Test(arguments: [true, false])
+    func `emits connected with direction and id when a call connects`(isOutgoing: Bool) {
+        let callID = UUID()
+        let direction: NIDCallStatusObserverService.Direction = isOutgoing ? .outgoing : .incoming
+
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: false,
+            hasConnected: true,
+            direction: direction,
+            callID: callID
+        )
+
+        assertLastEvent(
+            state: .connected,
+            direction: direction,
+            callID: callID
+        )
+    }
+
+    @Test
+    func `emits onHold with direction and id after a connected call is placed on hold`() {
+        let callID = UUID()
+
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: false,
+            hasConnected: true,
+            direction: .outgoing,
+            callID: callID
+        )
+
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: true,
+            hasConnected: false,
+            direction: .outgoing,
+            callID: callID
+        )
+
+        #expect(eventStorageService.mockEventStore.count == 2)
+        assertLastEvent(
+            state: .onHold,
+            direction: .outgoing,
+            callID: callID
+        )
+    }
+
+    @Test
+    func `emits connected again when a held call becomes active`() {
+        let callID = UUID()
+
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: false,
+            hasConnected: true,
+            direction: .incoming,
+            callID: callID
+        )
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: true,
+            hasConnected: false,
+            direction: .incoming,
+            callID: callID
+        )
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: false,
+            hasConnected: true,
+            direction: .incoming,
+            callID: callID
+        )
+
+        #expect(eventStorageService.mockEventStore.count == 3)
+        #expect(callStates() == [.connected, .onHold, .connected])
+        assertLastEvent(
+            state: .connected,
+            direction: .incoming,
+            callID: callID
+        )
+    }
+
+    @Test
+    func `emits disconnected with direction and id when a tracked call ends`() {
+        let callID = UUID()
+
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: false,
+            hasConnected: true,
+            direction: .outgoing,
+            callID: callID
+        )
+
+        callService.processCallChange(
+            hasEnded: true,
+            isOnHold: false,
+            hasConnected: false,
+            direction: .outgoing,
+            callID: callID
+        )
+
+        #expect(eventStorageService.mockEventStore.count == 2)
+        assertLastEvent(
+            state: .disconnected,
+            direction: .outgoing,
+            callID: callID
+        )
+    }
+
+    @Test
+    func `emits disconnected when the first observed state is ended`() {
+        let callID = UUID()
+
+        callService.processCallChange(
+            hasEnded: true,
+            isOnHold: false,
+            hasConnected: true,
+            direction: .incoming,
+            callID: callID
+        )
+
+        #expect(eventStorageService.mockEventStore.count == 1)
+        assertLastEvent(
+            state: .disconnected,
+            direction: .incoming,
+            callID: callID
+        )
+    }
+
+    @Test
+    func `emits nothing for calls that are only ringing`() {
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: false,
+            hasConnected: false,
+            direction: .incoming,
+            callID: UUID()
+        )
+
+        #expect(eventStorageService.mockEventStore.isEmpty)
+    }
+
+    @Test
+    func `does not eemit duplicate events for repeated callbacks of the same state`() {
+        let callID = UUID()
+
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: false,
+            hasConnected: true,
+            direction: .outgoing,
+            callID: callID
+        )
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: false,
+            hasConnected: true,
+            direction: .outgoing,
+            callID: callID
+        )
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: true,
+            hasConnected: false,
+            direction: .outgoing,
+            callID: callID
+        )
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: true,
+            hasConnected: false,
+            direction: .outgoing,
+            callID: callID
+        )
+        callService.processCallChange(
+            hasEnded: true,
+            isOnHold: false,
+            hasConnected: false,
+            direction: .outgoing,
+            callID: callID
+        )
+        callService.processCallChange(
+            hasEnded: true,
+            isOnHold: false,
+            hasConnected: false,
+            direction: .outgoing,
+            callID: callID
+        )
+
+        #expect(eventStorageService.mockEventStore.count == 3)
+        #expect(callStates() == [.connected, .onHold, .disconnected])
+    }
+
+    @Test
+    func `emits only onHold when the first observed state is on hold`() {
+        let callID = UUID()
+
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: true,
+            hasConnected: false,
+            direction: .incoming,
+            callID: callID
+        )
+
+        #expect(eventStorageService.mockEventStore.count == 1)
+        #expect(callStates() == [.onHold])
+        assertLastEvent(
+            state: .onHold,
+            direction: .incoming,
+            callID: callID
+        )
+    }
+
+    @Test
+    func `tracks simultaneous calls independetly`() {
+        let firstCallID = UUID()
+        let secondCallID = UUID()
+
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: false,
+            hasConnected: true,
+            direction: .incoming,
+            callID: firstCallID
+        )
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: true,
+            hasConnected: false,
+            direction: .incoming,
+            callID: firstCallID
+        )
+        callService.processCallChange(
+            hasEnded: false,
+            isOnHold: false,
+            hasConnected: true,
+            direction: .outgoing,
+            callID: secondCallID
+        )
+        callService.processCallChange(
+            hasEnded: true,
+            isOnHold: false,
+            hasConnected: false,
+            direction: .outgoing,
+            callID: secondCallID
+        )
+        callService.processCallChange(
+            hasEnded: true,
+            isOnHold: false,
+            hasConnected: false,
+            direction: .incoming,
+            callID: firstCallID
+        )
+
+        #expect(eventStorageService.mockEventStore.count == 5)
+        #expect(callStates() == [.connected, .onHold, .connected, .disconnected, .disconnected])
+    }
+
+    private func assertLastEvent(
+        state: NIDCallStatusObserverService.CallPhase,
+        direction: NIDCallStatusObserverService.Direction,
+        callID: UUID
+    ) {
+        let lastEvent = eventStorageService.mockEventStore.last
+
+        #expect(lastEvent?.cp == state.rawValue)
+        #expect(lastEvent?.attrs?.first(where: { $0.n == "direction" })?.v == direction.rawValue)
+        #expect(lastEvent?.attrs?.first(where: { $0.n == "id" })?.v == callID.uuidString)
+    }
+
+    func callStates() -> [NIDCallStatusObserverService.CallPhase] {
+        eventStorageService.mockEventStore.compactMap {
+            NIDCallStatusObserverService.CallPhase(rawValue: $0.cp!)
+        }
+    }
+}

--- a/SDKTest/Services/NIDCallStatusObserverServiceTests.swift
+++ b/SDKTest/Services/NIDCallStatusObserverServiceTests.swift
@@ -23,8 +23,8 @@ struct NIDCallStatusObserverServiceTests {
         )
     }
 
-    @Test(arguments: [true, false])
-    func `emits connected with direction and id when a call connects`(isOutgoing: Bool) {
+    @Test("emits connected with direction and id when a call connects", arguments: [true, false])
+    func emitsConnectedEvent(isOutgoing: Bool) {
         let callID = UUID()
         let direction: NIDCallStatusObserverService.Direction = isOutgoing ? .outgoing : .incoming
 
@@ -43,8 +43,8 @@ struct NIDCallStatusObserverServiceTests {
         )
     }
 
-    @Test
-    func `emits onHold with direction and id after a connected call is placed on hold`() {
+    @Test("emits onHold with direction and id after a connected call is placed on hold")
+    func emitsOnHoldAfterConnected() {
         let callID = UUID()
 
         callService.processCallChange(
@@ -71,8 +71,8 @@ struct NIDCallStatusObserverServiceTests {
         )
     }
 
-    @Test
-    func `emits connected again when a held call becomes active`() {
+    @Test("emits connected again when a held call becomes active")
+    func emitsConnectedWhenResumedFromHold() {
         let callID = UUID()
 
         callService.processCallChange(
@@ -106,8 +106,8 @@ struct NIDCallStatusObserverServiceTests {
         )
     }
 
-    @Test
-    func `emits disconnected with direction and id when a tracked call ends`() {
+    @Test("emits disconnected with direction and id when a tracked call ends")
+    func emitsDisconnectedWhenTrackedCallEnds() {
         let callID = UUID()
 
         callService.processCallChange(
@@ -134,8 +134,8 @@ struct NIDCallStatusObserverServiceTests {
         )
     }
 
-    @Test
-    func `emits disconnected when the first observed state is ended`() {
+    @Test("emits disconnected when the first observed state is ended")
+    func emitsDisconnectedWhenFirstStateIsEnded() {
         let callID = UUID()
 
         callService.processCallChange(
@@ -154,8 +154,8 @@ struct NIDCallStatusObserverServiceTests {
         )
     }
 
-    @Test
-    func `emits nothing for calls that are only ringing`() {
+    @Test("emits nothing for calls that are only ringing")
+    func emitsNothingForRingingOnly() {
         callService.processCallChange(
             hasEnded: false,
             isOnHold: false,
@@ -167,8 +167,8 @@ struct NIDCallStatusObserverServiceTests {
         #expect(eventStorageService.mockEventStore.isEmpty)
     }
 
-    @Test
-    func `does not eemit duplicate events for repeated callbacks of the same state`() {
+    @Test("does not eemit duplicate events for repeated callbacks of the same state")
+    func doesNotEmitDuplicateEvents() {
         let callID = UUID()
 
         callService.processCallChange(
@@ -218,8 +218,8 @@ struct NIDCallStatusObserverServiceTests {
         #expect(callStates() == [.connected, .onHold, .disconnected])
     }
 
-    @Test
-    func `emits only onHold when the first observed state is on hold`() {
+    @Test("emits only onHold when the first observed state is on hold")
+    func emitsOnHoldWhenFirstStateIsOnHold() {
         let callID = UUID()
 
         callService.processCallChange(
@@ -239,8 +239,8 @@ struct NIDCallStatusObserverServiceTests {
         )
     }
 
-    @Test
-    func `tracks simultaneous calls independetly`() {
+    @Test("tracks simultaneous calls independetly")
+    func tracksSimultaneousCalls() {
         let firstCallID = UUID()
         let secondCallID = UUID()
 

--- a/Source/NeuroID/Constants.swift
+++ b/Source/NeuroID/Constants.swift
@@ -57,17 +57,3 @@ enum SessionOrigin: String {
     case NID_ORIGIN_CODE_NID = "200"
     case NID_ORIGIN_CODE_CUSTOMER = "201"
 }
-
-enum CallInProgress: String {
-    case ACTIVE = "true"
-    case INACTIVE = "false"
-}
-
-enum CallInProgressMetaData: String {
-    case OUTGOING = "outgoing"
-    case INCOMING = "incoming"
-    case ANSWERED = "answered"
-    case ENDED = "ended"
-    case ONHOLD = "onhold"
-    case RINGING = "ringing"
-}

--- a/Source/NeuroID/Services/NIDCallStatusObserverService.swift
+++ b/Source/NeuroID/Services/NIDCallStatusObserverService.swift
@@ -41,7 +41,7 @@ class NIDCallStatusObserverService: NSObject, CXCallObserverDelegate, CallStatus
             callID: call.uuid
         )
     }
-    
+
     func processCallChange(
         hasEnded: Bool, isOnHold: Bool, hasConnected: Bool, direction: Direction, callID: UUID
     ) {
@@ -49,7 +49,7 @@ class NIDCallStatusObserverService: NSObject, CXCallObserverDelegate, CallStatus
 
         if hasEnded {
             guard previousPhase != .disconnected else { return }
-            
+
             emitCallEvent(
                 state: .disconnected,
                 direction: direction,
@@ -58,10 +58,10 @@ class NIDCallStatusObserverService: NSObject, CXCallObserverDelegate, CallStatus
             callStates[callID] = .disconnected
             return
         }
-        
+
         if isOnHold {
             guard previousPhase != .onHold else { return }
-            
+
             emitCallEvent(
                 state: .onHold,
                 direction: direction,
@@ -70,10 +70,10 @@ class NIDCallStatusObserverService: NSObject, CXCallObserverDelegate, CallStatus
             callStates[callID] = .onHold
             return
         }
-        
+
         if hasConnected {
             guard previousPhase != .connected else { return }
-            
+
             emitCallEvent(
                 state: .connected,
                 direction: direction,
@@ -83,13 +83,13 @@ class NIDCallStatusObserverService: NSObject, CXCallObserverDelegate, CallStatus
             return
         }
     }
-    
+
     private func emitCallEvent(state: CallPhase, direction: Direction, callID: UUID) {
         let attrs = [
             Attrs(n: "direction", v: direction.rawValue),
             Attrs(n: "id", v: callID.uuidString)
         ]
-        
+
         self.eventStorageService.saveEventToLocalDataStore(
             NIDEvent(
                 type: .callInProgress,
@@ -98,7 +98,7 @@ class NIDCallStatusObserverService: NSObject, CXCallObserverDelegate, CallStatus
             )
         )
     }
-    
+
     func startListeningToCallStatus() {
         if !self.isRegistered {
             if self.configService.configCache.callInProgress {
@@ -107,7 +107,7 @@ class NIDCallStatusObserverService: NSObject, CXCallObserverDelegate, CallStatus
             }
         }
     }
-    
+
     func stopListeningToCallStatus() {
         if self.isRegistered {
             self.callObserver.setDelegate(nil, queue: nil)

--- a/Source/NeuroID/Services/NIDCallStatusObserverService.swift
+++ b/Source/NeuroID/Services/NIDCallStatusObserverService.swift
@@ -16,10 +16,11 @@ protocol CallStatusObserverServiceProtocol {
 class NIDCallStatusObserverService: NSObject, CXCallObserverDelegate, CallStatusObserverServiceProtocol {
     private let callObserver = CXCallObserver()
     private var isRegistered = false
-    
+    private var callStates: [UUID: CallPhase] = [:]
+
     private let eventStorageService: EventStorageServiceProtocol
     private let configService: ConfigServiceProtocol
-    
+
     init(
         eventStorageService: EventStorageServiceProtocol,
         configService: ConfigServiceProtocol
@@ -32,38 +33,68 @@ class NIDCallStatusObserverService: NSObject, CXCallObserverDelegate, CallStatus
     }
 
     func callObserver(_ callObserver: CXCallObserver, callChanged call: CXCall) {
-        var status: String
-        var attrs: [Attrs] = []
-        var progress: String
-        
-        // Add call type
-        attrs.append(Attrs(n: "type", v: call.isOutgoing ? CallInProgressMetaData.OUTGOING.rawValue : CallInProgressMetaData.INCOMING.rawValue))
-        
-        if call.hasEnded {
-            status = CallInProgress.INACTIVE.rawValue
-            progress = CallInProgressMetaData.ENDED.rawValue
+        processCallChange(
+            hasEnded: call.hasEnded,
+            isOnHold: call.isOnHold,
+            hasConnected: call.hasConnected,
+            direction: call.isOutgoing ? .outgoing : .incoming,
+            callID: call.uuid
+        )
+    }
+    
+    func processCallChange(
+        hasEnded: Bool, isOnHold: Bool, hasConnected: Bool, direction: Direction, callID: UUID
+    ) {
+        let previousPhase = callStates[callID]
+
+        if hasEnded {
+            guard previousPhase != .disconnected else { return }
             
-        } else if call.isOnHold {
-            status = CallInProgress.ACTIVE.rawValue
-            progress = CallInProgressMetaData.ONHOLD.rawValue
-            
-        } else if call.hasConnected {
-            status = CallInProgress.ACTIVE.rawValue
-            progress = CallInProgressMetaData.ANSWERED.rawValue
-            
-        } else {
-            status = CallInProgress.INACTIVE.rawValue
-            progress = CallInProgressMetaData.RINGING.rawValue
+            emitCallEvent(
+                state: .disconnected,
+                direction: direction,
+                callID: callID
+            )
+            callStates[callID] = .disconnected
+            return
         }
         
-        // Add call progress
-        attrs.append(Attrs(n: "progress", v: progress))
+        if isOnHold {
+            guard previousPhase != .onHold else { return }
+            
+            emitCallEvent(
+                state: .onHold,
+                direction: direction,
+                callID: callID
+            )
+            callStates[callID] = .onHold
+            return
+        }
+        
+        if hasConnected {
+            guard previousPhase != .connected else { return }
+            
+            emitCallEvent(
+                state: .connected,
+                direction: direction,
+                callID: callID
+            )
+            callStates[callID] = .connected
+            return
+        }
+    }
+    
+    private func emitCallEvent(state: CallPhase, direction: Direction, callID: UUID) {
+        let attrs = [
+            Attrs(n: "direction", v: direction.rawValue),
+            Attrs(n: "id", v: callID.uuidString)
+        ]
         
         self.eventStorageService.saveEventToLocalDataStore(
             NIDEvent(
                 type: .callInProgress,
                 attrs: attrs,
-                cp: status
+                cp: state.rawValue
             )
         )
     }
@@ -81,6 +112,17 @@ class NIDCallStatusObserverService: NSObject, CXCallObserverDelegate, CallStatus
         if self.isRegistered {
             self.callObserver.setDelegate(nil, queue: nil)
             self.isRegistered = false
+            self.callStates.removeAll()
         }
+    }
+}
+
+extension NIDCallStatusObserverService {
+    enum CallPhase: String {
+        case connected, disconnected, onHold
+    }
+
+    enum Direction: String {
+        case incoming, outgoing
     }
 }


### PR DESCRIPTION
Update call state tracking with `direction` and `id`.


Event Payload Fields (`CALL_IN_PROGRESS`)
- `type`: `CALL_IN_PROGRESS`
- `cp`: call status (`connected`, `disconnected`, `onHold`)
- `attrs`
  - `direction`: who initiated the call (`incoming`, `outgoing`)
  - `id`: UUID of the call getting a status update

[ENG-11808] 

[ENG-11808]: https://neuro-id.atlassian.net/browse/ENG-11808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ