### PR TITLE
[ENG-11143] Stop persistently storing client key

### DIFF
--- a/SDKTest/BaseTestClass.swift
+++ b/SDKTest/BaseTestClass.swift
@@ -13,7 +13,6 @@ class BaseTestClass: XCTestCase {
     let clientKey = "key_live_vtotrandom_form_mobilesandbox"
 
     // Keys for storage:
-    let clientKeyKey = Constants.storageClientKey.rawValue
     let clientIdKey = Constants.storageClientIDKey.rawValue
     let tabIdKey = Constants.storageTabIDKey.rawValue
     

--- a/SDKTest/NeuroIDClass/NIDClientSiteIdTests.swift
+++ b/SDKTest/NeuroIDClass/NIDClientSiteIdTests.swift
@@ -97,26 +97,6 @@ class NIDClientSiteIdTests: BaseTestClass {
         assert(result == neuroID.clientID)
     }
 
-    // getClientKeyFromLocalStorage
-    func test_getClientKeyFromLocalStorage_existing() {
-        let expectedValue = "testClientKey"
-
-        UserDefaults.standard.setValue(expectedValue, forKey: clientKeyKey)
-
-        let value = neuroID.getClientKeyFromLocalStorage()
-        assert(value == expectedValue)
-    }
-
-    func test_getClientKeyFromLocalStorage_nil() {
-        let expectedValue: String? = nil
-
-        UserDefaults.standard.setValue(expectedValue, forKey: clientKeyKey)
-
-        let value = neuroID.getClientKeyFromLocalStorage()
-        assert(value != expectedValue)
-        assert(value == "")
-    }
-
     // getClientKey
     func test_getClientKey_nil() {
         neuroID.clientKey = nil

--- a/SDKTest/NeuroIDClass/NeuroIDClassTests.swift
+++ b/SDKTest/NeuroIDClass/NeuroIDClassTests.swift
@@ -81,7 +81,6 @@ class NeuroIDClassTests: BaseTestClass {
         clearOutDataStore()
         // remove things configured in setup
         NeuroIDCore.shared.clientKey = nil
-        UserDefaults.standard.setValue(nil, forKey: clientKeyKey)
         UserDefaults.standard.setValue("testTabId", forKey: tabIdKey)
 
         let configuration = NeuroID.Configuration(
@@ -91,8 +90,7 @@ class NeuroIDClassTests: BaseTestClass {
         let configured = NeuroID.configure(configuration)
         assert(configured)
 
-        let clientKeyValue = UserDefaults.standard.string(forKey: clientKeyKey)
-        assert(clientKeyValue == clientKey)
+        assert(NeuroIDCore.shared.clientKey == clientKey)
 
         let tabIdValue = UserDefaults.standard.string(forKey: tabIdKey)
         assert(tabIdValue == nil)
@@ -120,15 +118,13 @@ class NeuroIDClassTests: BaseTestClass {
         // remove things configured in setup
         NeuroIDCore.shared.environment = Constants.environmentTest.rawValue
         NeuroIDCore.shared.clientKey = nil
-        UserDefaults.standard.setValue(nil, forKey: clientKeyKey)
         UserDefaults.standard.setValue("testTabId", forKey: tabIdKey)
 
         let configuration = NeuroID.Configuration(clientKey: "invalid_key", isAdvancedDevice: false)
         let configured = NeuroID.configure(configuration)
         assert(configured == false)
 
-        let clientKeyValue = UserDefaults.standard.string(forKey: clientKeyKey)
-        assert(clientKeyValue == nil)
+        assert(NeuroIDCore.shared.clientKey == nil)
 
         let tabIdValue = UserDefaults.standard.string(forKey: tabIdKey)
         assert(tabIdValue == "testTabId-invalid-client-key")

--- a/Source/NeuroID/Constants.swift
+++ b/Source/NeuroID/Constants.swift
@@ -13,7 +13,6 @@ enum Constants: String {
 
     case developmentURL = "https://receiver.neuro-dev.com/c"
 
-    case storageClientKey = "nid_key"
     case storageClientIDKey = "nid_cid"
     case storageTabIDKey = "nid_tid"
     case storageDeviceIDKey = "nid_did"

--- a/Source/NeuroID/Models/NIDEvent.swift
+++ b/Source/NeuroID/Models/NIDEvent.swift
@@ -19,7 +19,6 @@ enum NIDEventName: String {
     case setLinkedSite = "SET_LINKED_SITE"
     case configCached = "CONFIG_CACHED"
 
-    case error = "ERROR"
     case log = "LOG"
     case registerTarget = "REGISTER_TARGET"
     case focus = "FOCUS"

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDClientSiteId.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDClientSiteId.swift
@@ -30,11 +30,6 @@ extension NeuroIDCore {
         return newClientID
     }
 
-    func getClientKeyFromLocalStorage() -> String {
-        let key = getUserDefaultKeyString(Constants.storageClientKey.rawValue)
-        return key ?? ""
-    }
-
     func getClientKey() -> String {
         guard let key = self.clientKey else {
             NIDLog.error("ClientKey is not set")

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDRegistration.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDRegistration.swift
@@ -14,10 +14,6 @@ extension NeuroIDCore {
         self.excludedViewsTestIDs.append(excludedView)
     }
 
-    func excludeViewByTestID(excludedView: String) {
-        self.excludeViewByTestID(excludedView)
-    }
-
     /**
         Specifically available for the React Native SDK to call and register all page targets due to lifecycle event delays
      */

--- a/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
+++ b/Source/NeuroID/NeuroIDClass/NeuroIDCore.swift
@@ -220,8 +220,6 @@ class NeuroIDCore: NSObject {
 
         self.clearSessionVariables()
 
-        setUserDefaultKey(Constants.storageClientKey.rawValue, value: clientKey)
-
         // Reset tab id / packet number on configure
         setUserDefaultKey(Constants.storageTabIDKey.rawValue, value: nil)
         self.saveEventToDataStore(


### PR DESCRIPTION
Stop storing `clientKey` to device storage, it is never retrieved and is dead code. Also removes an unused event type (`ERROR`) and a duplicated method (`excludeViewByTestID`).

[ENG-11143]

[ENG-11143]: https://neuro-id.atlassian.net/browse/ENG-11143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ