### PR TITLE
[ENG-12064] Restore `sessionID` to `SessionStartResult`

### DIFF
--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -12,6 +12,11 @@ public struct SessionStartResult {
     public let started: Bool
     public let identityId: String
 
+    @available(*, deprecated, message: "Use identityId instead")
+    public var sessionID: String {
+        return identityId
+    }
+
     init(_ started: Bool, _ identityId: String) {
         self.started = started
         self.identityId = identityId

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDSession.swift
@@ -12,7 +12,7 @@ public struct SessionStartResult {
     public let started: Bool
     public let identityId: String
 
-    @available(*, deprecated, message: "Use identityId instead")
+    @available(*, deprecated, renamed: "identityId")
     public var sessionID: String {
         return identityId
     }


### PR DESCRIPTION
Restore `sessionID` property to `SessionStartResult` and mark it as deprecated to make it a backwards compatible change.

[ENG-12064]

[ENG-12064]: https://neuro-id.atlassian.net/browse/ENG-12064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ