### PR TITLE
[ENG-12146] Restore jsVersion to event packet

### DIFF
--- a/Source/NeuroID/Models/NIDEvent.swift
+++ b/Source/NeuroID/Models/NIDEvent.swift
@@ -206,6 +206,7 @@ struct NeuroHTTPRequest: Codable {
         case pageId
         case url
         case packetNumber
+        case jsVersion
     }
 }
 


### PR DESCRIPTION
Restore `jsVersion` property to the event packet.

[ENG-12146]

[ENG-12146]: https://neuro-id.atlassian.net/browse/ENG-12146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ