### PR TITLE
[ENG-12157] Remove unused screen parameter

### DIFF
--- a/SDKTest/NeuroIDClass/NIDDataExtensionTests.swift
+++ b/SDKTest/NeuroIDClass/NIDDataExtensionTests.swift
@@ -5,12 +5,11 @@
 //  Created by Kevin Sites on 1/21/25.
 //
 
-@testable import NeuroID
 import XCTest
 
+@testable import NeuroID
+
 class NIDDataExtensionTests: BaseTestClass {
-    let eventsKey = "test_events_stored"
-    let screenName = "test_screen_name"
 
     let nidEvent = NIDEvent(
         type: .radioChange
@@ -38,7 +37,7 @@ class NIDDataExtensionTests: BaseTestClass {
     func test_saveEventToLocalDataStore_stoppedSDK() {
         _ = NeuroID.stop()
 
-        NeuroIDCore.shared.saveEventToLocalDataStore(nidEvent, screen: screenName)
+        NeuroIDCore.shared.saveEventToLocalDataStore(nidEvent)
         assert(dataStore.events.count == 0)
     }
 
@@ -52,7 +51,7 @@ class NIDDataExtensionTests: BaseTestClass {
         let nidE = nidEvent
         assert(nidE.url == nil)
 
-        NeuroIDCore.shared.saveEventToLocalDataStore(nidE, screen: screenName)
+        NeuroIDCore.shared.saveEventToLocalDataStore(nidE)
         assert(dataStore.events.count == 1)
         assert(dataStore.events[0].url == "ios://\(screen)")
     }
@@ -64,7 +63,7 @@ class NIDDataExtensionTests: BaseTestClass {
         let nidE = nidEvent
         assert(nidE.url == nil)
 
-        NeuroIDCore.shared.saveQueuedEventToLocalDataStore(nidE, screen: screenName)
+        NeuroIDCore.shared.saveQueuedEventToLocalDataStore(nidE)
         assert(dataStore.events.count == 0)
         assert(dataStore.queuedEvents.count == 1)
         assert(dataStore.queuedEvents[0].url == "ios://\(screen)")
@@ -74,7 +73,7 @@ class NIDDataExtensionTests: BaseTestClass {
         var nidE = nidEvent
         nidE.url = "RNScreensNavigationController"
 
-        NeuroIDCore.shared.cleanAndStoreEvent(screen: screenName, event: nidE, storeType: "")
+        NeuroIDCore.shared.cleanAndStoreEvent(event: nidE, storeType: "")
         assert(dataStore.events.count == 0)
     }
 
@@ -86,7 +85,7 @@ class NIDDataExtensionTests: BaseTestClass {
             "tgs": TargetValue.string(excludeId)
         ]
 
-        NeuroIDCore.shared.cleanAndStoreEvent(screen: screenName, event: nidE, storeType: "")
+        NeuroIDCore.shared.cleanAndStoreEvent(event: nidE, storeType: "")
         assert(dataStore.events.count == 0)
     }
 
@@ -97,7 +96,7 @@ class NIDDataExtensionTests: BaseTestClass {
 
         nidE.tgs = excludeId
 
-        NeuroIDCore.shared.cleanAndStoreEvent(screen: screenName, event: nidE, storeType: "")
+        NeuroIDCore.shared.cleanAndStoreEvent(event: nidE, storeType: "")
         assert(dataStore.events.count == 0)
     }
 
@@ -108,7 +107,7 @@ class NIDDataExtensionTests: BaseTestClass {
 
         nidE.en = excludeId
 
-        NeuroIDCore.shared.cleanAndStoreEvent(screen: screenName, event: nidE, storeType: "")
+        NeuroIDCore.shared.cleanAndStoreEvent(event: nidE, storeType: "")
         assert(dataStore.events.count == 0)
     }
 }

--- a/Source/NeuroID/NeuroIDClass/Extensions/NIDDataStore.swift
+++ b/Source/NeuroID/NeuroIDClass/Extensions/NIDDataStore.swift
@@ -20,36 +20,36 @@ extension NeuroIDCore {
         NIDEventName.advancedDeviceRequestFailed.rawValue,
         NIDEventName.blur.rawValue,
         NIDEventName.windowBlur.rawValue,
-        NIDEventName.closeSession.rawValue,
+        NIDEventName.closeSession.rawValue
     ]
 
     /**
         Save and event to the datastore (logic of queue or not contained in this function)
      */
-    func saveEventToDataStore(_ event: NIDEvent, screen: String? = nil) {
+    func saveEventToDataStore(_ event: NIDEvent) {
         if !self.isSDKStarted {
-            self.saveQueuedEventToLocalDataStore(event, screen: screen)
+            self.saveQueuedEventToLocalDataStore(event)
         } else {
-            self.saveEventToLocalDataStore(event, screen: screen)
+            self.saveEventToLocalDataStore(event)
         }
     }
 
-    func saveEventToLocalDataStore(_ event: NIDEvent, screen: String? = nil) {
+    func saveEventToLocalDataStore(_ event: NIDEvent) {
         if self.isStopped() {
             return
         }
 
-        self.cleanAndStoreEvent(screen: screen ?? event.type, event: event, storeType: "event")
+        self.cleanAndStoreEvent(event: event, storeType: "event")
     }
 
-    func saveQueuedEventToLocalDataStore(_ event: NIDEvent, screen: String? = nil) {
-        self.cleanAndStoreEvent(screen: screen ?? event.type, event: event, storeType: "queue")
+    func saveQueuedEventToLocalDataStore(_ event: NIDEvent) {
+        self.cleanAndStoreEvent(event: event, storeType: "queue")
     }
 
     /**
             Method to clean incoming events, prevent unwanted events, and attach metadata fields
      */
-    func cleanAndStoreEvent(screen: String, event: NIDEvent, storeType: String) {
+    func cleanAndStoreEvent(event: NIDEvent, storeType: String) {
         // If we hit a low memory event, drop events and early return
         //  OR if we are not sampling the session (i.e. are throttling)
         //  then drop events

--- a/Source/NeuroID/NeuroIDTracker.swift
+++ b/Source/NeuroID/NeuroIDTracker.swift
@@ -25,11 +25,10 @@ class NeuroIDTracker: NSObject {
     }
 
     public func captureEvent(event: NIDEvent) {
-        let screenName = screen ?? ParamsCreator.generateID()
         var newEvent = event
         // Make sure we have a valid url set
         newEvent.url = NeuroID.getScreenName()
-        NeuroIDCore.shared.saveEventToLocalDataStore(newEvent, screen: screenName)
+        NeuroIDCore.shared.saveEventToLocalDataStore(newEvent)
     }
 
     public static func registerSingleView(

--- a/Source/NeuroID/Services/EventStorageService.swift
+++ b/Source/NeuroID/Services/EventStorageService.swift
@@ -7,10 +7,8 @@
 
 protocol EventStorageServiceProtocol {
     func saveEventToDataStore(_ event: NIDEvent)
-    func saveEventToDataStore(_ event: NIDEvent, screen: String?)
 
     func saveEventToLocalDataStore(_ event: NIDEvent)
-    func saveEventToLocalDataStore(_ event: NIDEvent, screen: String?)
 }
 
 struct EventStorageService: EventStorageServiceProtocol {
@@ -18,15 +16,7 @@ struct EventStorageService: EventStorageServiceProtocol {
         NeuroIDCore.shared.saveEventToDataStore(event)
     }
 
-    func saveEventToDataStore(_ event: NIDEvent, screen: String? = nil) {
-        NeuroIDCore.shared.saveEventToDataStore(event, screen: screen)
-    }
-
     func saveEventToLocalDataStore(_ event: NIDEvent) {
         NeuroIDCore.shared.saveEventToLocalDataStore(event)
-    }
-
-    func saveEventToLocalDataStore(_ event: NIDEvent, screen: String? = nil) {
-        NeuroIDCore.shared.saveEventToLocalDataStore(event, screen: screen)
     }
 }

--- a/Source/NeuroID/Services/ListenerManagerService.swift
+++ b/Source/NeuroID/Services/ListenerManagerService.swift
@@ -96,9 +96,6 @@ extension ListenerManagerService {
     fileprivate func captureEvent(event: NIDEvent) {
         var event = event
         event.url = NeuroID.getScreenName()
-        NeuroIDCore.shared.saveEventToLocalDataStore(
-            event,
-            screen: NeuroID.getScreenName() ?? ParamsCreator.generateID()
-        )
+        NeuroIDCore.shared.saveEventToLocalDataStore(event)
     }
 }

--- a/Source/NeuroID/TrackerClassExtensions/UIClassExtensions/UIViewController.swift
+++ b/Source/NeuroID/TrackerClassExtensions/UIClassExtensions/UIViewController.swift
@@ -208,8 +208,7 @@ extension UIViewController {
                         Attrs(n: "screenHeightTotal", v: "\(UIScreen.main.bounds.size.height)"),
                         Attrs(n: "screenWidthTotal", v: "\(UIScreen.main.bounds.size.width)"),
                     ]
-                ),
-                screen: nidClassName
+                )
             )
         }
     }
@@ -227,8 +226,7 @@ extension UIViewController {
                 attrs: [
                     Attrs(n: "appear", v: "\(false)"),
                 ]
-            ),
-            screen: nidClassName
+            )
         )
     }
 }

--- a/Source/NeuroID/TrackerClassExtensions/Utils.swift
+++ b/Source/NeuroID/TrackerClassExtensions/Utils.swift
@@ -194,8 +194,7 @@ enum UtilFunctions {
                 v: lengthValue,
                 hv: hashValue,
                 url: screenName
-            ),
-            screen: screenName
+            )
         )
     }
 

--- a/Source/NeuroID/TrackerEvents/TouchEvents.swift
+++ b/Source/NeuroID/TrackerEvents/TouchEvents.swift
@@ -91,7 +91,7 @@ func captureTouchEvent(
     let tg: [String: TargetValue] = [
         "\(Constants.tgsKey.rawValue)": TargetValue.string(viewName),
         "\(Constants.etnKey.rawValue)": TargetValue.string(viewClass),
-        "location": TargetValue.string("gestureRecognizer"),
+        "location": TargetValue.string("gestureRecognizer")
     ]
 
     var attrs: [Attrs] = []
@@ -107,7 +107,6 @@ func captureTouchEvent(
             url: NeuroID.getScreenName(),
             attrs: attrs,
             touches: touchArray
-        ),
-        screen: viewClass
+        )
     )
 }


### PR DESCRIPTION
Remove `screen` parameter from `cleanAndStoreEvent` and all of its parent callers. It is unused throughout the SD and can be safely removed.

[ENG-12157]

[ENG-12157]: https://neuro-id.atlassian.net/browse/ENG-12157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ